### PR TITLE
Replace table with consumer group in the Vertica offset table

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - '*'
     tags-ignore:
       - 'v*'
 

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaContext.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaContext.scala
@@ -21,6 +21,11 @@ import scala.jdk.CollectionConverters._
 trait KafkaContext {
 
   /**
+    * The consumer group ID.
+    */
+  val consumerGroup: String
+
+  /**
     * Retrieves the committed offsets for the given topic partitions from Kafka.
     */
   def committed(topicPartitions: Set[TopicPartition]): Map[TopicPartition, Option[OffsetAndMetadata]]
@@ -39,7 +44,12 @@ trait KafkaContext {
   * @param consumer Kafka consumer to use.
   * @param lock Lock to synchronize on.
   */
-class LockingKafkaContext(consumer: KafkaConsumer[Array[Byte], Array[Byte]], lock: ReentrantLock) extends KafkaContext {
+class LockingKafkaContext(
+    consumer: KafkaConsumer[Array[Byte], Array[Byte]],
+    val consumerGroup: String,
+    lock: ReentrantLock
+) extends KafkaContext {
+
   def committed(topicPartitions: Set[TopicPartition]): Map[TopicPartition, Option[OffsetAndMetadata]] = withLock {
     consumer.committed(topicPartitions.asJava).asScala.map(kv => (kv._1, Option(kv._2))).toMap
   }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaSource.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaSource.scala
@@ -13,7 +13,7 @@ import java.util.Properties
 import java.util.concurrent.locks.ReentrantLock
 
 import com.adform.streamloader.model.StreamPosition
-import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 
 import scala.jdk.CollectionConverters._
@@ -56,7 +56,8 @@ class KafkaSource(consumerProperties: Properties, topics: Seq[String], pollTimeo
   def initialize(): KafkaContext = {
     consumerLock = new ReentrantLock()
     consumer = new KafkaConsumer[Array[Byte], Array[Byte]](props)
-    new LockingKafkaContext(consumer, consumerLock)
+    val consumerGroup = props.get(ConsumerConfig.GROUP_ID_CONFIG).toString
+    new LockingKafkaContext(consumer, consumerGroup, consumerLock)
   }
 
   /**

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/MockKafkaContext.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/MockKafkaContext.scala
@@ -24,6 +24,8 @@ class MockKafkaContext extends KafkaContext {
     failOnCommit = seqNo
   }
 
+  override val consumerGroup: String = "mock-consumer-group"
+
   override def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): Unit = {
     commitsInvoked += 1
     if (failOnCommit == commitsInvoked) {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Docker.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Docker.scala
@@ -60,12 +60,6 @@ trait Docker {
 
   def dockerInit(): Unit = {
     network = createNetwork()
-
-    // Check if it's a drone build - if so, join the build env to the same network
-    for {
-      _ <- sys.env.get("DRONE")
-      hostname <- sys.env.get("HOSTNAME")
-    } yield docker.connectToNetwork(hostname, dockerNetwork.id)
   }
 
   def dockerCleanup(): Unit =

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/Vertica.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/Vertica.scala
@@ -64,7 +64,7 @@ CREATE SEQUENCE file_id_sequence;
 
 CREATE TABLE file_offsets (
   _file_id INT NOT NULL,
-  _table VARCHAR(128) NOT NULL,
+  _consumer_group VARCHAR(1024) NOT NULL,
   _topic VARCHAR(128) NOT NULL,
   _partition INT NOT NULL,
   _start_offset INT NOT NULL,


### PR DESCRIPTION
Previously the external offset Vertica storage would store offsets for each table being loaded in the offset table, now it stores the consumer group instead of the table being loaded. In order to make this work, we also add a `consumerGroup` member to `KafkaContext`, which allows sinks to know the consumer group ID.

Also fix CI so that it runs on branches and remove legacy network setup in Docker integration tests.