### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
     - name: Setup Git Token
-      uses: fregante/setup-git-user@v1        
+      uses: fregante/setup-git-user@v1
 
     - name: Publish to Sonatype
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,7 @@ jobs:
         PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
     - name: Setup Git Token
-      uses: fregante/setup-git-token@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}        
+      uses: fregante/setup-git-user@v1        
 
     - name: Publish to Sonatype
       env:


### PR DESCRIPTION
In the v2 of `actions/checkout`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user