### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 
 on:
-  push:
+  pull_request:
     branches:
       - '*'
     tags-ignore:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 target/
+.bsp
+.metals
+.bloop
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ ThisBuild / developers := List(
 enablePlugins(GitVersioning)
 ThisBuild / git.useGitDescribe := true
 
+ThisBuild / useCoursier := false
+
 val gitRepo = "git@github.com:adform/stream-loader.git"
 val gitRepoUrl = "https://github.com/adform/stream-loader"
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ ThisBuild / useCoursier := false
 val gitRepo = "git@github.com:adform/stream-loader.git"
 val gitRepoUrl = "https://github.com/adform/stream-loader"
 
-val scalaTestVersion = "3.2.0"
-val scalaCheckVersion = "1.14.3"
-val scalaCheckTestVersion = "3.2.0.0"
+val scalaTestVersion = "3.2.8"
+val scalaCheckVersion = "1.15.3"
+val scalaCheckTestVersion = "3.2.8.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -33,17 +33,17 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"    % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"  % "kafka-clients"     % "2.5.0",
-      "org.log4s"         %% "log4s"            % "1.8.2",
+      "org.apache.kafka"  % "kafka-clients"     % "2.8.0",
+      "org.log4s"         %% "log4s"            % "1.9.0",
       "org.anarres.lzo"   % "lzo-commons"       % "1.0.6",
-      "org.xerial.snappy" % "snappy-java"       % "1.1.7.6",
+      "org.xerial.snappy" % "snappy-java"       % "1.1.8.4",
       "org.lz4"           % "lz4-java"          % "1.7.1",
-      "com.github.luben"  % "zstd-jni"          % "1.4.5-4" classifier "linux_amd64",
-      "com.univocity"     % "univocity-parsers" % "2.8.4",
-      "org.json4s"        %% "json4s-native"    % "3.6.9",
-      "io.micrometer"     % "micrometer-core"   % "1.5.2",
+      "com.github.luben"  % "zstd-jni"          % "1.4.9-5",
+      "com.univocity"     % "univocity-parsers" % "2.9.1",
+      "org.json4s"        %% "json4s-native"    % "3.6.11",
+      "io.micrometer"     % "micrometer-core"   % "1.6.6",
       "org.scalatest"     %% "scalatest"        % scalaTestVersion % "test",
-      "org.scalatestplus" %% "scalacheck-1-14"  % scalaCheckTestVersion % "test",
+      "org.scalatestplus" %% "scalacheck-1-15"  % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"       % scalaCheckVersion % "test",
       "ch.qos.logback"    % "logback-classic"   % "1.2.3" % "test"
     ),
@@ -60,15 +60,16 @@ lazy val `stream-loader-clickhouse` = project
   .dependsOn(`stream-loader-core` % "compile->compile;test->test")
   .settings(commonSettings)
   .settings(
+    resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "ru.yandex.clickhouse" % "clickhouse-jdbc"  % "0.2.4",
+      "ru.yandex.clickhouse" % "clickhouse-jdbc"  % "0.3.0",
       "org.scalatest"        %% "scalatest"       % scalaTestVersion % "test",
-      "org.scalatestplus"    %% "scalacheck-1-14" % scalaCheckTestVersion % "test",
+      "org.scalatestplus"    %% "scalacheck-1-15" % scalaCheckTestVersion % "test",
       "org.scalacheck"       %% "scalacheck"      % scalaCheckVersion % "test"
     )
   )
 
-val parquetVersion = "1.11.0"
+val parquetVersion = "1.12.0"
 
 lazy val `stream-loader-hadoop` = project
   .in(file("stream-loader-hadoop"))
@@ -76,10 +77,10 @@ lazy val `stream-loader-hadoop` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.sksamuel.avro4s" %% "avro4s-core"     % "3.1.1",
+      "com.sksamuel.avro4s" %% "avro4s-core"     % "4.0.7",
       "org.apache.parquet"  % "parquet-avro"     % parquetVersion,
       "org.apache.parquet"  % "parquet-protobuf" % parquetVersion,
-      "org.apache.hadoop"   % "hadoop-client"    % "3.2.1" exclude ("log4j", "log4j"),
+      "org.apache.hadoop"   % "hadoop-client"    % "3.2.2" exclude ("log4j", "log4j"),
       "org.scalatest"       %% "scalatest"       % scalaTestVersion % "test"
     )
   )
@@ -90,10 +91,10 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.13.42",
+      "software.amazon.awssdk" % "s3"              % "2.16.46",
       "org.scalatest"          %% "scalatest"      % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.11.808" % "test",
-      "org.gaul"               % "s3proxy"         % "1.7.1" % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.11.1003" % "test",
+      "org.gaul"               % "s3proxy"         % "1.8.0" % "test",
     )
   )
 
@@ -108,7 +109,7 @@ lazy val `stream-loader-vertica` = project
     libraryDependencies ++= Seq(
       (("com.vertica"     % "vertica-jdbc"     % verticaVersion) from verticaJarUrl) % "provided",
       "org.scalatest"     %% "scalatest"       % scalaTestVersion                    % "test",
-      "org.scalatestplus" %% "scalacheck-1-14" % scalaCheckTestVersion               % "test",
+      "org.scalatestplus" %% "scalacheck-1-15" % scalaCheckTestVersion               % "test",
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion                   % "test"
     )
   )
@@ -132,13 +133,13 @@ lazy val `stream-loader-tests` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe"      % "config"           % "1.4.0",
+      "com.typesafe"      % "config"           % "1.4.1",
       "ch.qos.logback"    % "logback-classic"  % "1.2.3",
-      "com.zaxxer"        % "HikariCP"         % "3.4.5",
+      "com.zaxxer"        % "HikariCP"         % "4.0.3",
       "com.vertica"       % "vertica-jdbc"     % verticaVersion from verticaJarUrl,
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion,
       "org.scalatest"     %% "scalatest"       % scalaTestVersion % "test,it",
-      "org.scalatestplus" %% "scalacheck-1-14" % scalaCheckTestVersion % "test,it",
+      "org.scalatestplus" %% "scalacheck-1-15" % scalaCheckTestVersion % "test,it",
       ("com.spotify"      % "docker-client"    % "8.16.0" classifier "shaded") % "it"
     ),
     test := {}, // only integration tests present
@@ -171,7 +172,7 @@ lazy val `stream-loader-tests` = project
       val bin = s"/opt/${name.value}/bin/"
 
       new Dockerfile {
-        from("adoptopenjdk:11.0.7_10-jre-hotspot")
+        from("adoptopenjdk:11.0.10_9-jre-hotspot")
 
         env("APP_CLASS_PATH" -> s"$lib/*")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "stream-loader"
 
 ThisBuild / organization := "com.adform"
 ThisBuild / organizationName := "Adform"
-ThisBuild / scalaVersion := "2.13.3"
+ThisBuild / scalaVersion := "2.13.5"
 ThisBuild / scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-target:jvm-1.8")
 
 ThisBuild / startYear := Some(2020)
@@ -144,7 +144,7 @@ lazy val `stream-loader-tests` = project
     test := {}, // only integration tests present
     publish := {},
     publishLocal := {},
-    skip in publish := true,
+    publish / skip := true,
     buildInfoPackage := s"${organization.value}.streamloader",
     buildInfoKeys := Seq[BuildInfoKey](
       name,
@@ -164,7 +164,7 @@ lazy val `stream-loader-tests` = project
       (libDir, appLibDir)
     },
     dockerImage := s"adform/${name.value}:${version.value}",
-    dockerfile in docker := {
+    docker / dockerfile := {
 
       val (depLib, appLib) = packAndSplitJars.value
       val lib = s"/opt/${name.value}/lib"
@@ -192,7 +192,7 @@ lazy val `stream-loader-tests` = project
         )
       }
     },
-    imageNames in docker := {
+    docker / imageNames := {
       val Array(dockerImageName, dockerTag) = dockerImage.value.split(":")
       val Array(dockerNs, dockerRepo) = dockerImageName.split("/")
       Seq(
@@ -203,10 +203,10 @@ lazy val `stream-loader-tests` = project
         )
       )
     },
-    test in IntegrationTest := (test in IntegrationTest).dependsOn(docker).value,
-    testOnly in IntegrationTest := (testOnly in IntegrationTest).dependsOn(docker).evaluated,
+    IntegrationTest / test := (IntegrationTest / test).dependsOn(docker).value,
+    IntegrationTest / testOnly := (IntegrationTest / testOnly).dependsOn(docker).evaluated,
     // Prevents slf4j replay warnings during tests
-    testOptions in IntegrationTest ++= Seq(
+    IntegrationTest / testOptions ++= Seq(
       sbt.Tests.Setup(
         cl =>
           cl.loadClass("org.slf4j.LoggerFactory")
@@ -244,7 +244,7 @@ lazy val commonSettings = Seq(
   },
 
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   publishTo := sonatypePublishToBundle.value,
 
   homepage := Some(url(gitRepoUrl)),
@@ -262,9 +262,9 @@ lazy val `stream-loader` = project
   .settings(
     publish := {},
     publishLocal := {},
-    skip in publish := true,
-    scalacOptions in (Compile, doc) ++= Seq("-doc-title", name.value),
-    unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(`stream-loader-tests`),
+    publish / skip := true,
+    Compile / doc / scalacOptions ++= Seq("-doc-title", name.value),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(`stream-loader-tests`),
     copyDocAssets := Def.taskDyn {
       val filter = ScopeFilter(inProjects(thisProject.value.aggregate: _*))
       val destination = thisProject.value.base / "target" / "diagrams"
@@ -278,10 +278,10 @@ lazy val `stream-loader` = project
         destination
       }
     }.value,
-    makeSite := makeSite.dependsOn(unidoc in Compile).value,
-    addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc),
-    siteSubdirName in ScalaUnidoc := "",
-    mappings in makeSite ++= {
+    makeSite := makeSite.dependsOn(Compile / unidoc).value,
+    addMappingsToSiteDir(ScalaUnidoc / packageDoc / mappings, ScalaUnidoc / siteSubdirName),
+    ScalaUnidoc / siteSubdirName := "",
+    makeSite / mappings ++= {
       val diagramDir = copyDocAssets.value
       diagramDir
         .listFiles()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.12")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
@@ -14,10 +14,10 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2020.15"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2021.4"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
@@ -18,6 +18,6 @@ libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2021.4"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/parquet/AvroParquetFileBuilderFactory.scala
+++ b/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/parquet/AvroParquetFileBuilderFactory.scala
@@ -17,6 +17,7 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.avro.AvroParquetWriter
+import org.apache.parquet.hadoop.util.HadoopOutputFile
 
 /**
   * Parquet file builder for records of any data type that have implicitly defined Avro encoders.
@@ -28,11 +29,12 @@ class AvroParquetFileBuilderFactory[R: Encoder: Decoder: SchemaFor](compression:
   private val recordFormat = RecordFormat[R]
 
   override def newFileBuilder(filenamePrefix: String): FileBuilder[R] = {
+    val conf = new Configuration()
     val file = getFile(filenamePrefix)
     val writer = AvroParquetWriter
-      .builder[GenericRecord](new Path(file.getAbsolutePath))
+      .builder[GenericRecord](HadoopOutputFile.fromPath(new Path(file.getAbsolutePath), conf))
       .withSchema(AvroSchema[R])
-      .withConf(new Configuration())
+      .withConf(conf)
       .withCompressionCodec(compressionCodecName)
       .build()
     val genericBuilder = new ParquetFileBuilder(file, writer)(currentTimeMills)

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:20.4.6.53")
+case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:21.4.3.21")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Hdfs.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Hdfs.scala
@@ -17,8 +17,8 @@ import org.log4s._
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 case class HdfsConfig(
-    namenodeImage: String = "bde2020/hadoop-namenode:2.0.0-hadoop3.1.3-java8",
-    datanodeImage: String = "bde2020/hadoop-datanode:2.0.0-hadoop3.1.3-java8"
+    namenodeImage: String = "bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8",
+    datanodeImage: String = "bde2020/hadoop-datanode:2.0.0-hadoop3.2.1-java8"
 )
 
 trait HdfsTestFixture extends Hdfs with BeforeAndAfterAll { this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-case class KafkaConfig(image: String = "johnnypark/kafka-zookeeper:2.4.0")
+case class KafkaConfig(image: String = "johnnypark/kafka-zookeeper:2.6.0")
 
 trait KafkaTestFixture extends Kafka with BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2020-07-02T00-15-09Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2021-04-06T23-11-00Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {


### PR DESCRIPTION
Version updates:
 - sbt 1.5.0, fixed deprecation warnings,
 - scala 2.13.5,
 - all other libraries and test docker images.

Also disabled coursier, as referencing jars from external URLs (needed for the vertica JDBC driver) seems broken, see https://github.com/sbt/sbt/issues/5418.