### PR TITLE
Implement file partitioning for HDFS/S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         java-version: 1.8
 
     - name: Run Tests
-      run: sbt -Dsbt.color=always -Dsbt.supershell=false scalafmtCheck headerCheckAll test it:test
+      run: sbt -Dsbt.color=always -Dsbt.supershell=false scalafmtCheck scalafmtSbtCheck headerCheckAll test it:test

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `stream-loader-core` = project
       "org.anarres.lzo"   % "lzo-commons"       % "1.0.6",
       "org.xerial.snappy" % "snappy-java"       % "1.1.8.4",
       "org.lz4"           % "lz4-java"          % "1.7.1",
-      "com.github.luben"  % "zstd-jni"          % "1.4.9-5",
+      "com.github.luben"  % "zstd-jni"          % "1.5.0-2",
       "com.univocity"     % "univocity-parsers" % "2.9.1",
       "org.json4s"        %% "json4s-native"    % "4.0.0",
       "io.micrometer"     % "micrometer-core"   % "1.7.0",
@@ -91,9 +91,9 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.16.74",
+      "software.amazon.awssdk" % "s3"              % "2.16.86",
       "org.scalatest"          %% "scalatest"      % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.11.1030" % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.8" % "test",
       "org.gaul"               % "s3proxy"         % "1.8.0" % "test",
     )
   )
@@ -172,7 +172,7 @@ lazy val `stream-loader-tests` = project
       val bin = s"/opt/${name.value}/bin/"
 
       new Dockerfile {
-        from("adoptopenjdk:11.0.10_9-jre-hotspot")
+        from("adoptopenjdk:11.0.11_9-jre-hotspot")
 
         env("APP_CLASS_PATH" -> s"$lib/*")
 

--- a/build.sbt
+++ b/build.sbt
@@ -243,11 +243,9 @@ lazy val commonSettings = Seq(
         outFile
       })
   },
-
   publishMavenStyle := true,
   Test / publishArtifact := false,
   publishTo := sonatypePublishToBundle.value,
-
   homepage := Some(url(gitRepoUrl)),
   scmInfo := Some(ScmInfo(url(gitRepoUrl), s"scm:git:$gitRepo"))
 )

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
@@ -14,7 +14,7 @@ import com.adform.streamloader.batch.RecordFormatter
 import com.adform.streamloader.file.{BaseFileRecordBatcher, FileCommitStrategy}
 import com.adform.streamloader.model.RecordRange
 
-class ClickHouseFileRecordBatcher[R] protected (
+class ClickHouseFileRecordBatcher[R](
     recordFormatter: RecordFormatter[R],
     fileBuilderFactory: ClickHouseFileBuilderFactory[R],
     fileCommitStrategy: FileCommitStrategy

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
@@ -14,7 +14,7 @@ import com.adform.streamloader.batch.RecordFormatter
 import com.adform.streamloader.file.{BaseFileRecordBatcher, FileCommitStrategy}
 import com.adform.streamloader.model.RecordRange
 
-class ClickHouseFileRecordBatcher[R](
+class ClickHouseFileRecordBatcher[+R](
     recordFormatter: RecordFormatter[R],
     fileBuilderFactory: ClickHouseFileBuilderFactory[R],
     fileCommitStrategy: FileCommitStrategy

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSink.scala
@@ -29,7 +29,7 @@ import scala.jdk.DurationConverters._
   * @tparam B Type of record batches.
   * @define RecordBatchStorage [[com.adform.streamloader.batch.storage.RecordBatchStorage RecordBatchStorage]]
   */
-class RecordBatchingSink[+B <: RecordBatch] protected (
+class RecordBatchingSink[+B <: RecordBatch](
     recordBatcher: RecordBatcher[B],
     batchStorage: RecordBatchStorage[B],
     batchCommitQueueSize: Int,

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordPartitioner.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordPartitioner.scala
@@ -16,7 +16,7 @@ import com.adform.streamloader.model.Record
   * @tparam R Type of formatted records, i.e. the one being written to storage.
   * @tparam P Type of the partition.
   */
-trait RecordPartitioner[R, P] {
+trait RecordPartitioner[-R, +P] {
 
   /**
     * Gets the partition this record belongs to.

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordPartitioner.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordPartitioner.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.batch
+
+import com.adform.streamloader.model.Record
+
+/**
+  * Base trait for defining a record partitioning strategy, e.g. by day or by country, etc.
+  *
+  * @tparam R Type of formatted records, i.e. the one being written to storage.
+  * @tparam P Type of the partition.
+  */
+trait RecordPartitioner[R, P] {
+
+  /**
+    * Gets the partition this record belongs to.
+    *
+    * @param raw The original un-formatted record.
+    * @param formatted The formatted record.
+    * @return The partition the record should be routed to.
+    */
+  def partition(raw: Record, formatted: R): P
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/FilePathFormatter.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/FilePathFormatter.scala
@@ -11,15 +11,16 @@ package com.adform.streamloader.file
 import com.adform.streamloader.model.RecordRange
 
 /**
-  * Base trait used to construct file paths given ranges of records they contain.
+  * Base trait used to construct file paths when storing files to persistent storages.
   */
-trait FilePathFormatter {
+trait FilePathFormatter[-P] {
 
   /**
-    * Constructs a file path given the ranges of records contained in the file.
+    * Constructs a file path given the partition and ranges of records contained in the file.
     *
-    * @param ranges Ranges of records in the file.
+    * @param partition The partition of records in the file.
+    * @param recordRanges Ranges of records in the file.
     * @return A relative path for the file.
     */
-  def formatPath(ranges: Seq[RecordRange]): String
+  def formatPath(partition: P, recordRanges: Seq[RecordRange]): String
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/FileRecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/FileRecordBatcher.scala
@@ -73,7 +73,7 @@ abstract class BaseFileRecordBatcher[+R, +B <: BaseFileRecordBatch](
   *
   * @tparam R Type of records being written to files.
   */
-class FileRecordBatcher[+R] protected (
+class FileRecordBatcher[+R](
     recordFormatter: RecordFormatter[R],
     fileBuilderFactory: FileBuilderFactory[R],
     fileCommitStrategy: FileCommitStrategy

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/MultiFileCommitStrategy.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/MultiFileCommitStrategy.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.file
+
+import java.time.Duration
+
+case class FileStats(fileOpenDuration: Duration, fileSize: Long, recordsWritten: Long)
+
+/**
+  * Trait for defining a strategy for completing a multi-file batch.
+  */
+trait MultiFileCommitStrategy {
+
+  /**
+    * Returns whether a file batch is complete given the stats of the files.
+    */
+  def shouldCommit(files: Seq[FileStats]): Boolean
+}
+
+object MultiFileCommitStrategy {
+  def anyFile(single: FileCommitStrategy): MultiFileCommitStrategy = (files: Seq[FileStats]) =>
+    files.exists(fs => single.shouldCommit(fs.fileOpenDuration, fs.fileSize, fs.recordsWritten))
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/MultiFileCommitStrategy.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/MultiFileCommitStrategy.scala
@@ -24,6 +24,7 @@ trait MultiFileCommitStrategy {
 }
 
 object MultiFileCommitStrategy {
-  def anyFile(single: FileCommitStrategy): MultiFileCommitStrategy = (files: Seq[FileStats]) =>
-    files.exists(fs => single.shouldCommit(fs.fileOpenDuration, fs.fileSize, fs.recordsWritten))
+  def anyFile(single: FileCommitStrategy): MultiFileCommitStrategy =
+    (files: Seq[FileStats]) =>
+      files.exists(fs => single.shouldCommit(fs.fileOpenDuration, fs.fileSize, fs.recordsWritten))
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitionedFileRecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitionedFileRecordBatch.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.file
+
+import com.adform.streamloader.model.{RecordBatch, RecordRange}
+
+/**
+  * A record batch that is partitioned by some value, e.g. by date.
+  *
+  * @param partitionBatches Mapping of file record batch per partition.
+  * @tparam P Type of the partitioning information, e.g. date or a tuple of client/country, etc.
+  * @tparam B Type of the file record batches.
+  */
+case class PartitionedFileRecordBatch[P, +B <: BaseFileRecordBatch](partitionBatches: Map[P, B]) extends RecordBatch {
+
+  def fileBatches: Seq[B] = partitionBatches.values.toSeq
+
+  final override def recordRanges: Seq[RecordRange] = {
+    fileBatches
+      .flatMap(_.recordRanges)
+      .groupBy(r => (r.topic, r.partition))
+      .map {
+        case ((topic, partition), ranges) =>
+          RecordRange(topic, partition, ranges.map(_.start).min, ranges.map(_.end).max)
+      }
+      .toSeq
+  }
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitioningFileRecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitioningFileRecordBatcher.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.file
+
+import com.adform.streamloader.batch.{RecordBatcher, RecordFormatter, RecordPartitioner}
+import com.adform.streamloader.file.FileCommitStrategy.ReachedAnyOf
+import com.adform.streamloader.model.{Record, RecordBatchBuilder}
+import com.adform.streamloader.util.TimeProvider
+
+import java.time.Duration
+import scala.collection.concurrent.TrieMap
+
+/**
+  * A record batcher that distributes records into user defined partitions using a given partitioner
+  * and writes them to separate files per partition.
+  *
+  * @param recordFormatter Record formatter to use when writing to files.
+  * @param recordPartitioner Partitioner for distributing records to partitions.
+  * @param fileBuilderFactory File builder factory to use.
+  * @param fileCommitStrategy File commit strategy to use.
+  * @tparam P Type of the partition values.
+  * @tparam R Type of formatted records.
+  */
+class PartitioningFileRecordBatcher[P, R](
+    recordFormatter: RecordFormatter[R],
+    recordPartitioner: RecordPartitioner[R, P],
+    fileBuilderFactory: FileBuilderFactory[R],
+    fileCommitStrategy: MultiFileCommitStrategy
+)(implicit timeProvider: TimeProvider = TimeProvider.system)
+    extends RecordBatcher[PartitionedFileRecordBatch[P, FileRecordBatch]] {
+
+  private case class FileRecordBatchBuilder(startTimeMs: Long, fileBuilder: FileBuilder[R])
+      extends RecordBatchBuilder[FileRecordBatch] {
+
+    def write(record: Record, formattedRecord: R): Unit = {
+      add(record)
+      fileBuilder.write(formattedRecord)
+    }
+    override def isBatchReady: Boolean = false
+
+    override def build(): Option[FileRecordBatch] =
+      fileBuilder.build().map(f => FileRecordBatch(f, currentRecordRanges))
+
+    override def discard(): Unit = fileBuilder.discard()
+  }
+
+  override def newBatchBuilder(): RecordBatchBuilder[PartitionedFileRecordBatch[P, FileRecordBatch]] =
+    new RecordBatchBuilder[PartitionedFileRecordBatch[P, FileRecordBatch]] {
+
+      private val partitionBuilders: TrieMap[P, FileRecordBatchBuilder] = TrieMap.empty
+
+      override def add(record: Record): Unit = {
+        super.add(record)
+        recordFormatter
+          .format(record)
+          .foreach(formatted => {
+            val partition = recordPartitioner.partition(record, formatted)
+            val partitionBuilder = partitionBuilders.getOrElseUpdate(
+              partition,
+              FileRecordBatchBuilder(timeProvider.currentMillis, fileBuilderFactory.newFileBuilder())
+            )
+            partitionBuilder.write(record, formatted)
+          })
+      }
+
+      override def isBatchReady: Boolean = fileCommitStrategy.shouldCommit(
+        partitionBuilders.map {
+          case (_, partitionBuilder) =>
+            FileStats(
+              Duration.ofMillis(timeProvider.currentMillis - partitionBuilder.startTimeMs),
+              partitionBuilder.fileBuilder.getDataSize,
+              partitionBuilder.fileBuilder.getRecordCount
+            )
+        }.toSeq
+      )
+
+      override def build(): Option[PartitionedFileRecordBatch[P, FileRecordBatch]] = {
+        val batches = for {
+          (partition, builder) <- partitionBuilders
+          batch <- builder.build()
+        } yield (partition, batch)
+
+        if (batches.nonEmpty)
+          Some(PartitionedFileRecordBatch(batches.toMap))
+        else
+          None
+      }
+
+      override def discard(): Unit = partitionBuilders.values.foreach(_.discard())
+    }
+}
+
+object PartitioningFileRecordBatcher {
+
+  case class Builder[P, R](
+    private val _fileBuilderFactory: FileBuilderFactory[R],
+    private val _recordFormatter: RecordFormatter[R],
+    private val _recordPartitioner: RecordPartitioner[R, P],
+    private val _fileCommitStrategy: MultiFileCommitStrategy
+  ) {
+
+    /**
+      * Sets the record formatter that converts from consumer records to records written to the file.
+      */
+    def recordFormatter(formatter: RecordFormatter[R]): Builder[P, R] = copy(_recordFormatter = formatter)
+
+    /**
+      * Sets the record partitioner to use for distributing records to partitions.
+      */
+    def recordPartitioner(partitioner: RecordPartitioner[R, P]): Builder[P, R] = copy(_recordPartitioner = partitioner)
+    /**
+      * Sets the file builder factory, e.g. CSV.
+      */
+    def fileBuilderFactory(factory: FileBuilderFactory[R]): Builder[P, R] = copy(_fileBuilderFactory = factory)
+
+    /**
+      * Sets the strategy for determining if a batch of files is ready.
+      */
+    def fileCommitStrategy(strategy: MultiFileCommitStrategy): Builder[P, R] = copy(_fileCommitStrategy = strategy)
+
+    def build(): PartitioningFileRecordBatcher[P, R] = {
+      if (_recordFormatter == null) throw new IllegalStateException("Must specify a RecordFormatter")
+      if (_recordPartitioner == null) throw new IllegalStateException("Must specify a RecordPartitioner")
+      if (_fileBuilderFactory == null) throw new IllegalStateException("Must specify a FileBuilderFactory")
+
+      new PartitioningFileRecordBatcher(
+        _recordFormatter,
+        _recordPartitioner,
+        _fileBuilderFactory,
+        _fileCommitStrategy,
+      )
+    }
+  }
+
+  def builder[P, R](): Builder[P, R] = Builder[P, R](
+    _fileBuilderFactory = null,
+    _recordFormatter = null,
+    _recordPartitioner = null,
+    _fileCommitStrategy = MultiFileCommitStrategy.anyFile(ReachedAnyOf(recordsWritten = Some(1000)))
+  )
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitioningFileRecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitioningFileRecordBatcher.scala
@@ -99,10 +99,10 @@ class PartitioningFileRecordBatcher[P, R](
 object PartitioningFileRecordBatcher {
 
   case class Builder[P, R](
-    private val _fileBuilderFactory: FileBuilderFactory[R],
-    private val _recordFormatter: RecordFormatter[R],
-    private val _recordPartitioner: RecordPartitioner[R, P],
-    private val _fileCommitStrategy: MultiFileCommitStrategy
+      private val _fileBuilderFactory: FileBuilderFactory[R],
+      private val _recordFormatter: RecordFormatter[R],
+      private val _recordPartitioner: RecordPartitioner[R, P],
+      private val _fileCommitStrategy: MultiFileCommitStrategy
   ) {
 
     /**
@@ -114,6 +114,7 @@ object PartitioningFileRecordBatcher {
       * Sets the record partitioner to use for distributing records to partitions.
       */
     def recordPartitioner(partitioner: RecordPartitioner[R, P]): Builder[P, R] = copy(_recordPartitioner = partitioner)
+
     /**
       * Sets the file builder factory, e.g. CSV.
       */

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/model/Timestamp.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/model/Timestamp.scala
@@ -9,8 +9,7 @@
 package com.adform.streamloader.model
 
 import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDateTime, ZoneId}
-
+import java.time._
 import scala.util.Try
 
 /**
@@ -30,6 +29,10 @@ case class Timestamp(millis: Long) extends AnyVal with Ordered[Timestamp] {
       .ofInstant(Instant.ofEpochMilli(millis), ZoneId.of("UTC"))
       .format(DateTimeFormatter.ofPattern(pattern))
   }
+
+  def toInstant: Instant = Instant.ofEpochMilli(millis)
+  def toDate: LocalDate = toInstant.atOffset(ZoneOffset.UTC).toLocalDate
+  def toDateTime: LocalDateTime = toInstant.atOffset(ZoneOffset.UTC).toLocalDateTime
 
   override def compare(that: Timestamp): Int = millis.compare(that.millis)
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/util/TimeExtractor.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/util/TimeExtractor.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.util
+
+import com.adform.streamloader.model.Timestamp
+
+import java.time.{LocalDate, ZoneId}
+
+/**
+  * Type-class for extracting epoch milliseconds from various time representations.
+  */
+trait TimeExtractor[P] {
+  def extractTime(value: P): Timestamp
+}
+
+object TimeExtractor {
+  implicit val localDate: TimeExtractor[LocalDate] =
+    (value: LocalDate) => Timestamp(value.atStartOfDay(ZoneId.of("UTC")).toInstant.toEpochMilli)
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/FileStaging.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/FileStaging.scala
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package com.adform.streamloader.file
+package com.adform.streamloader.batch.storage
 
 import com.adform.streamloader.util.JsonSerializer
 import org.json4s.JsonAST._

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/MockTwoPhaseCommitFileStorage.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/MockTwoPhaseCommitFileStorage.scala
@@ -8,7 +8,7 @@
 
 package com.adform.streamloader.batch.storage
 
-import com.adform.streamloader.file.{FileRecordBatch, FileStaging}
+import com.adform.streamloader.file.FileRecordBatch
 
 import scala.collection.mutable
 

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/TwoPhaseCommitFileStorageTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/batch/storage/TwoPhaseCommitFileStorageTest.scala
@@ -8,15 +8,15 @@
 
 package com.adform.streamloader.batch.storage
 
-import java.io.File
-
 import com.adform.streamloader.MockKafkaContext
-import com.adform.streamloader.file.{FileRecordBatch, FileStaging}
+import com.adform.streamloader.file.FileRecordBatch
 import com.adform.streamloader.model.{RecordRange, StreamPosition, Timestamp}
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.io.File
 
 class TwoPhaseCommitFileStorageTest extends AnyFunSpec with Matchers {
 

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.file
+
+import com.adform.streamloader.encoding.csv.CsvFileBuilderFactory
+import com.adform.streamloader.model.{Record, RecordRange, StreamPosition, Timestamp}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.record.TimestampType
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+class PartitioningFileRecordBatcherTest extends AnyFunSpec with Matchers {
+
+  describe("mod 10 partitioning batcher with a 100 records") {
+
+    val batcher = new PartitioningFileRecordBatcher[Int, String](
+      (record: Record) => Seq(new String(record.consumerRecord.value(), "UTF-8")),
+      (record, value) => value.toInt % 10,
+      new CsvFileBuilderFactory[String](Compression.NONE),
+      stats => stats.exists(f => f.recordsWritten >= 20)
+    )
+
+    describe("with no records") {
+      val builder = batcher.newBatchBuilder()
+      val batch = builder.build()
+
+      it("should produce an empty batch") {
+        batch shouldEqual None
+      }
+    }
+
+    describe("with a 100 records in all partitions") {
+
+      val builder = batcher.newBatchBuilder()
+      for (i <- 0 until 100) {
+        builder.add(newRecord("topic", 0, Timestamp(i), i, "key", i.toString))
+      }
+
+      it("should not be ready yet") {
+        builder.isBatchReady shouldEqual false
+      }
+
+      val maybePartitionedBatch = builder.build()
+
+      it("should produce a bath") {
+        maybePartitionedBatch.nonEmpty shouldBe true
+      }
+
+      val partitionedBatch = maybePartitionedBatch.get
+
+      it("should produce 10 partitions") {
+        partitionedBatch.partitionBatches.size shouldEqual 10
+      }
+
+      it("should produce batches with 10 records each") {
+        partitionedBatch.partitionBatches.values.forall(b => readAllLines(b.file).size == 10) shouldEqual true
+      }
+
+      it("should produce correctly partitioned batches") {
+        partitionedBatch.partitionBatches.foreach {
+          case (partition, batch) =>
+            readAllLines(batch.file).forall(line => line.toInt % 10 == partition) shouldBe true
+        }
+      }
+
+      it("should have correct overall record ranges") {
+        partitionedBatch.recordRanges should contain theSameElementsAs
+          Seq(RecordRange("topic", 0, StreamPosition(0, Timestamp(0)), StreamPosition(99, Timestamp(99))))
+      }
+    }
+
+    describe("with 30 records in the same partition") {
+
+      val builder = batcher.newBatchBuilder()
+      for (i <- 0 until 1000) {
+        builder.add(newRecord("topic", 0, Timestamp(i), i, "key", "1"))
+      }
+
+      it("should be ready by now") {
+        builder.isBatchReady shouldBe true
+      }
+
+      val partitionedBatch = builder.build()
+
+      it("should contain a single partition batch") {
+        partitionedBatch.get.partitionBatches.size shouldEqual 1
+      }
+    }
+  }
+
+  def newRecord(
+      topic: String,
+      partition: Int,
+      timestamp: Timestamp,
+      offset: Long,
+      key: String,
+      value: String): Record = {
+    val cr = new ConsumerRecord[Array[Byte], Array[Byte]](
+      topic,
+      partition,
+      offset,
+      timestamp.millis,
+      TimestampType.CREATE_TIME,
+      -1,
+      -1,
+      -1,
+      key.getBytes("UTF-8"),
+      value.getBytes("UTF-8")
+    )
+    Record(cr, timestamp)
+  }
+
+  def readAllLines(file: File): Seq[String] = Using.resource(Files.lines(file.toPath))(_.iterator().asScala.toSeq)
+}

--- a/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
+++ b/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
@@ -32,7 +32,6 @@ class HadoopFileStorage[P](
   private val stagingPath = new Path(stagingDirectory)
   private val basePath = new Path(destinationDirectory)
 
-
   override protected def stageBatch(batch: PartitionedFileRecordBatch[P, BaseFileRecordBatch]): MultiFileStaging = {
     val stagings = batch.partitionBatches.map {
       case (partition, fileBatch) => stageSingleBatch(partition, fileBatch)

--- a/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
+++ b/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
@@ -8,12 +8,12 @@
 
 package com.adform.streamloader.hadoop
 
-import java.io.IOException
-
 import com.adform.streamloader.batch.storage.TwoPhaseCommitBatchStorage
-import com.adform.streamloader.file.{BaseFileRecordBatch, FilePathFormatter, FileStaging}
+import com.adform.streamloader.file.{BaseFileRecordBatch, FilePathFormatter, PartitionedFileRecordBatch}
 import com.adform.streamloader.model.RecordRange
 import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.io.IOException
 
 /**
   * A Hadoop compatible file system based storage, most likely used for storing to HDFS.
@@ -21,21 +21,39 @@ import org.apache.hadoop.fs.{FileSystem, Path}
   * The prepare/commit phases for storing a file consist of first uploading it to a staging path
   * and later atomically moving it to the final destination path.
   */
-class HadoopFileStorage protected (
+class HadoopFileStorage[P](
     hadoopFS: FileSystem,
     stagingDirectory: String,
-    stagingFilePathFormatter: FilePathFormatter,
+    stagingFilePathFormatter: FilePathFormatter[P],
     destinationDirectory: String,
-    destinationFilePathFormatter: FilePathFormatter
-) extends TwoPhaseCommitBatchStorage[BaseFileRecordBatch, FileStaging] {
+    destinationFilePathFormatter: FilePathFormatter[P]
+) extends TwoPhaseCommitBatchStorage[PartitionedFileRecordBatch[P, BaseFileRecordBatch], MultiFileStaging] {
 
   private val stagingPath = new Path(stagingDirectory)
   private val basePath = new Path(destinationDirectory)
 
-  override protected def stageBatch(batch: BaseFileRecordBatch): FileStaging = {
+
+  override protected def stageBatch(batch: PartitionedFileRecordBatch[P, BaseFileRecordBatch]): MultiFileStaging = {
+    val stagings = batch.partitionBatches.map {
+      case (partition, fileBatch) => stageSingleBatch(partition, fileBatch)
+    }
+    log.debug(s"Successfully staged batch $batch")
+    MultiFileStaging(stagings.toSeq)
+  }
+
+  override protected def storeBatch(staging: MultiFileStaging): Unit = {
+    staging.fileStagings.foreach(fs => storeSingleBatch(fs))
+    log.info(s"Successfully stored staged batch $staging")
+  }
+
+  override protected def isBatchStored(staging: MultiFileStaging): Boolean = {
+    staging.fileStagings.forall(fs => isSingleBatchStored(fs))
+  }
+
+  private def stageSingleBatch(partition: P, batch: BaseFileRecordBatch): FileStaging = {
     val sourceFilePath = new Path(batch.file.toPath.toString)
-    val stagingFilePath = new Path(stagingPath, stagingFilePathFormatter.formatPath(batch.recordRanges))
-    val targetFilePath = new Path(basePath, destinationFilePathFormatter.formatPath(batch.recordRanges))
+    val stagingFilePath = new Path(stagingPath, stagingFilePathFormatter.formatPath(partition, batch.recordRanges))
+    val targetFilePath = new Path(basePath, destinationFilePathFormatter.formatPath(partition, batch.recordRanges))
 
     log.debug(s"Staging file $sourceFilePath to $stagingFilePath")
 
@@ -44,7 +62,7 @@ class HadoopFileStorage protected (
     FileStaging(stagingFilePath.toUri.toString, targetFilePath.toUri.toString)
   }
 
-  override protected def storeBatch(staging: FileStaging): Unit = {
+  private def storeSingleBatch(staging: FileStaging): Unit = {
     val stagingFilePath = new Path(staging.stagingPath)
     val targetFilePath = new Path(staging.destinationPath)
 
@@ -55,60 +73,61 @@ class HadoopFileStorage protected (
 
     log.debug(s"Moving staged file $stagingFilePath to the destination path $targetFilePath")
     if (!hadoopFS.rename(stagingFilePath, targetFilePath)) {
-      if (!isBatchStored(staging)) {
+      if (!isSingleBatchStored(staging)) {
         throw new IOException(
           s"Failed renaming file from $stagingFilePath to $targetFilePath, because $stagingFilePath does not exist")
       } else {
         throw new IOException(s"Failed renaming file from $stagingFilePath to $targetFilePath")
       }
     }
-    log.info(s"Successfully stored staged file $stagingFilePath to the destination path $targetFilePath")
+    log.debug(s"Successfully stored staged file $stagingFilePath to the destination path $targetFilePath")
   }
 
-  override protected def isBatchStored(staging: FileStaging): Boolean = {
+  private def isSingleBatchStored(staging: FileStaging): Boolean = {
     hadoopFS.exists(new Path(staging.destinationPath))
   }
 }
 
 object HadoopFileStorage {
 
-  case class Builder(
+  case class Builder[P](
       private val _hadoopFS: FileSystem,
       private val _stagingBasePath: String,
-      private val _stagingFilePathFormatter: FilePathFormatter,
+      private val _stagingFilePathFormatter: FilePathFormatter[P],
       private val _destinationBasePath: String,
-      private val _destinationFilePathFormatter: FilePathFormatter
+      private val _destinationFilePathFormatter: FilePathFormatter[P]
   ) {
 
     /**
       * Sets the Hadoop file system to use.
       */
-    def hadoopFS(fs: FileSystem): Builder = copy(_hadoopFS = fs)
+    def hadoopFS(fs: FileSystem): Builder[P] = copy(_hadoopFS = fs)
 
     /**
       * Sets the staging base path (directory) in the file system.
       */
-    def stagingBasePath(path: String): Builder = copy(_stagingBasePath = path)
+    def stagingBasePath(path: String): Builder[P] = copy(_stagingBasePath = path)
 
     /**
       * Sets the destination base path (directory) in the file system.
       */
-    def destinationBasePath(path: String): Builder = copy(_destinationBasePath = path)
+    def destinationBasePath(path: String): Builder[P] = copy(_destinationBasePath = path)
 
     /**
       * Sets the file path formatter for the staged files.
       * If not provided, the destination formatter is used with an additional ".tmp" suffix appended.
       */
-    def stagingFilePathFormatter(formatter: FilePathFormatter): Builder = copy(_stagingFilePathFormatter = formatter)
+    def stagingFilePathFormatter(formatter: FilePathFormatter[P]): Builder[P] =
+      copy(_stagingFilePathFormatter = formatter)
 
     /**
       * Sets the file path formatter for the destination files.
       * Can include a prefix directories for partitioning.
       */
-    def destinationFilePathFormatter(formatter: FilePathFormatter): Builder =
+    def destinationFilePathFormatter(formatter: FilePathFormatter[P]): Builder[P] =
       copy(_destinationFilePathFormatter = formatter)
 
-    def build(): HadoopFileStorage = {
+    def build(): HadoopFileStorage[P] = {
       if (_hadoopFS == null) throw new IllegalArgumentException("Must provide a Hadoop FileSystem")
       if (_stagingBasePath == null) throw new IllegalArgumentException("Staging base path must be provided")
       if (_destinationBasePath == null) throw new IllegalArgumentException("Destination base path must be provided")
@@ -118,13 +137,13 @@ object HadoopFileStorage {
       val stagingFormatter = if (_stagingFilePathFormatter != null) {
         _stagingFilePathFormatter
       } else {
-        new FilePathFormatter {
-          override def formatPath(ranges: Seq[RecordRange]): String =
-            _destinationFilePathFormatter.formatPath(ranges) + ".tmp"
+        new FilePathFormatter[P] {
+          override def formatPath(partition: P, ranges: Seq[RecordRange]): String =
+            _destinationFilePathFormatter.formatPath(partition, ranges) + ".tmp"
         }
       }
 
-      new HadoopFileStorage(
+      new HadoopFileStorage[P](
         _hadoopFS,
         _stagingBasePath,
         stagingFormatter,
@@ -133,5 +152,5 @@ object HadoopFileStorage {
     }
   }
 
-  def builder(): Builder = Builder(null, null, null, null, null)
+  def builder[P](): Builder[P] = Builder[P](null, null, null, null, null)
 }

--- a/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/MultiFileStaging.scala
+++ b/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/MultiFileStaging.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.hadoop
+
+import com.adform.streamloader.util.JsonSerializer
+import org.json4s.JArray
+import org.json4s.JsonAST.{JObject, JString, JValue}
+
+case class FileStaging(stagingPath: String, destinationPath: String)
+
+case class MultiFileStaging(fileStagings: Seq[FileStaging])
+
+object MultiFileStaging {
+
+  implicit val jsonSerializer: JsonSerializer[MultiFileStaging] = new JsonSerializer[MultiFileStaging] {
+
+    override def serialize(value: MultiFileStaging): JValue = JArray(
+      value.fileStagings
+        .map(fs => {
+          JObject("staged_file_path" -> JString(fs.stagingPath), "destination_file_path" -> JString(fs.destinationPath))
+        })
+        .toList
+    )
+
+    override def deserialize(json: JValue): MultiFileStaging = json match {
+      case JArray(items) =>
+        val stagings = items.map {
+          case JObject(fields) =>
+            val values = fields.toMap
+            FileStaging(extractString(values("staged_file_path")), extractString(values("destination_file_path")))
+          case o => throw new IllegalArgumentException(s"Object expected, but '$o' found")
+        }
+        MultiFileStaging(stagings)
+      case o => throw new IllegalArgumentException(s"Array expected, but '$o' found")
+    }
+  }
+
+  private def extractString(v: JValue): String = v match {
+    case JString(s) => s
+    case _ => throw new IllegalArgumentException(s"Expected a string, but found '$v'")
+  }
+}

--- a/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/MultiFileStagingTest.scala
+++ b/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/MultiFileStagingTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.hadoop
+
+import com.adform.streamloader.util.JsonSerializer
+import org.json4s.JsonAST.JValue
+import org.json4s.{JArray, JObject, JString}
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class MultiFileStagingTest extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
+
+  private val serializer = implicitly[JsonSerializer[MultiFileStaging]]
+
+  val testStaging: MultiFileStaging = MultiFileStaging(
+    Seq(
+      FileStaging("staged1", "destination1"),
+      FileStaging("staged2", "destination2")
+    ))
+
+  val testStagingJson: JValue = JArray(
+    List(
+      JObject("staged_file_path" -> JString("staged1"), "destination_file_path" -> JString("destination1")),
+      JObject("staged_file_path" -> JString("staged2"), "destination_file_path" -> JString("destination2"))
+    ))
+
+  val singleStagingGen: Gen[FileStaging] = for {
+    staged <- Gen.asciiPrintableStr
+    destination <- Gen.asciiPrintableStr
+  } yield FileStaging(staged, destination)
+
+  val stagingGen: Gen[MultiFileStaging] = Gen.listOf(singleStagingGen).map(l => MultiFileStaging(l))
+
+  implicit val arbitraryStaging: Arbitrary[MultiFileStaging] = Arbitrary(stagingGen)
+
+  it("should serialize correctly") {
+    serializer.serialize(testStaging) shouldEqual testStagingJson
+  }
+
+  it("should deserialize correctly") {
+    serializer.deserialize(testStagingJson) shouldEqual testStaging
+  }
+
+  it("should serialize and deserialize to the same thing") {
+    forAll { (staging: MultiFileStaging) =>
+      {
+        serializer.deserialize(serializer.serialize(staging)) shouldEqual staging
+      }
+    }
+  }
+}

--- a/stream-loader-s3/src/main/scala/com/adform/streamloader/s3/S3MultiFileStaging.scala
+++ b/stream-loader-s3/src/main/scala/com/adform/streamloader/s3/S3MultiFileStaging.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.s3
+
+import com.adform.streamloader.util.JsonSerializer
+import org.json4s.{JArray, JObject, JString, JValue}
+
+case class S3FileStaging(uploadId: String, uploadPartTag: String, destinationKey: String)
+
+case class S3MultiFileStaging(fileUploads: Seq[S3FileStaging])
+
+object S3MultiFileStaging {
+
+  implicit val jsonSerializer: JsonSerializer[S3MultiFileStaging] = new JsonSerializer[S3MultiFileStaging] {
+    override def serialize(value: S3MultiFileStaging): JValue = {
+      JArray(
+        value.fileUploads
+          .map(
+            fs =>
+              JObject(
+                "id" -> JString(fs.uploadId),
+                "part_tag" -> JString(fs.uploadPartTag),
+                "key" -> JString(fs.destinationKey)
+            ))
+          .toList)
+    }
+    override def deserialize(json: JValue): S3MultiFileStaging = json match {
+      case JArray(items) =>
+        S3MultiFileStaging(
+          items.map {
+            case JObject(obj) =>
+              val kvs = obj.toMap
+              S3FileStaging(
+                kvs("id").asInstanceOf[JString].s,
+                kvs("part_tag").asInstanceOf[JString].s,
+                kvs("key").asInstanceOf[JString].s
+              )
+            case o => throw new IllegalArgumentException(s"Object expected, but '$o' found")
+          }
+        )
+      case o => throw new IllegalArgumentException(s"Array expected, but '$o' found")
+    }
+  }
+}

--- a/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3MultiFileStagingTest.scala
+++ b/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3MultiFileStagingTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.s3
+
+import com.adform.streamloader.util.JsonSerializer
+import org.json4s.JsonAST.JValue
+import org.json4s.{JArray, JObject, JString}
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class S3MultiFileStagingTest extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
+
+  private val serializer = implicitly[JsonSerializer[S3MultiFileStaging]]
+
+  val testStaging: S3MultiFileStaging = S3MultiFileStaging(
+    Seq(S3FileStaging("upload1", "part1", "key1"), S3FileStaging("upload2", "part2", "key2")))
+
+  val testStagingJson: JValue = JArray(
+    List(
+      JObject("id" -> JString("upload1"), "part_tag" -> JString("part1"), "key" -> JString("key1")),
+      JObject("id" -> JString("upload2"), "part_tag" -> JString("part2"), "key" -> JString("key2"))
+    ))
+
+  val singleStagingGen: Gen[S3FileStaging] = for {
+    uploadId <- Gen.asciiPrintableStr
+    tag <- Gen.asciiPrintableStr
+    key <- Gen.asciiPrintableStr
+  } yield S3FileStaging(uploadId, tag, key)
+
+  val stagingGen: Gen[S3MultiFileStaging] = Gen.listOf(singleStagingGen).map(l => S3MultiFileStaging(l))
+
+  implicit val arbitraryStaging: Arbitrary[S3MultiFileStaging] = Arbitrary(stagingGen)
+
+  it("should serialize correctly") {
+    serializer.serialize(testStaging) shouldEqual testStagingJson
+  }
+
+  it("should deserialize correctly") {
+    serializer.deserialize(testStagingJson) shouldEqual testStaging
+  }
+
+  it("should serialize and deserialize to the same thing") {
+    forAll { (staging: S3MultiFileStaging) =>
+      {
+        serializer.deserialize(serializer.serialize(staging)) shouldEqual staging
+      }
+    }
+  }
+}

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:21.4.3.21")
+case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:21.6.4.26")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2021-04-06T23-11-00Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2021-06-17T00-10-46Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/HdfsStorageBackend.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/HdfsStorageBackend.scala
@@ -9,7 +9,6 @@
 package com.adform.streamloader.storage
 
 import java.util.UUID
-
 import com.adform.streamloader.file.{FilePathFormatter, TimePartitioningFilePathFormatter}
 import com.adform.streamloader.fixtures._
 import com.adform.streamloader.hadoop.HadoopFileStorage
@@ -25,6 +24,7 @@ import org.apache.parquet.avro.AvroParquetReader
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.scalacheck.Arbitrary
 
+import java.time.LocalDate
 import scala.math.BigDecimal.RoundingMode.RoundingMode
 
 case class HdfsStorageBackend(
@@ -41,7 +41,7 @@ case class HdfsStorageBackend(
   override def arbMessage: Arbitrary[ExampleMessage] = ExampleMessage.arbMessage
 
   private val timePartitionPathPattern = "'dt='yyyy'_'MM'_'dd"
-  private val pathFormatter: FilePathFormatter =
+  private val pathFormatter: TimePartitioningFilePathFormatter[LocalDate] =
     new TimePartitioningFilePathFormatter(Some(timePartitionPathPattern), None)
 
   implicit private val scalePrecision: ScalePrecision = ExampleMessage.SCALE_PRECISION

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/S3StorageBackend.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/S3StorageBackend.scala
@@ -8,8 +8,6 @@
 
 package com.adform.streamloader.storage
 
-import java.util.UUID
-
 import com.adform.streamloader.file.{FilePathFormatter, TimePartitioningFilePathFormatter}
 import com.adform.streamloader.fixtures._
 import com.adform.streamloader.model.{StreamPosition, StringMessage, Timestamp}
@@ -24,6 +22,8 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.utils.IoUtils
 
+import java.time.LocalDate
+import java.util.UUID
 import scala.jdk.CollectionConverters._
 
 case class LoaderS3Config(accessKey: String, secretKey: String, bucket: String)
@@ -41,7 +41,7 @@ case class S3StorageBackend(
   override def arbMessage: Arbitrary[StringMessage] = StringMessage.arbMessage
 
   private val timePartitionPathPattern = "'dt='yyyy'_'MM'_'dd"
-  private val pathFormatter: FilePathFormatter =
+  private val pathFormatter: FilePathFormatter[LocalDate] =
     new TimePartitioningFilePathFormatter(Some(timePartitionPathPattern), None)
 
   override def initialize(): Unit = {

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/S3.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/S3.scala
@@ -71,10 +71,9 @@ class BaseS3Loader extends Loader {
             .recordFormatter(recordFormatter)
             .recordPartitioner((r, _) => Timestamp(r.consumerRecord.timestamp()).toDate)
             .fileBuilderFactory(new CsvFileBuilderFactory(Compression.NONE))
-            .fileCommitStrategy(
-              MultiFileCommitStrategy.anyFile(
-                ReachedAnyOf(recordsWritten = Some(cfg.getLong("file.max.records")))
-              ))
+            .fileCommitStrategy(MultiFileCommitStrategy.anyFile(
+              ReachedAnyOf(recordsWritten = Some(cfg.getLong("file.max.records")))
+            ))
             .build()
         )
         .batchStorage(

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/S3.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/S3.scala
@@ -8,12 +8,11 @@
 
 package com.adform.streamloader.loaders
 
-import java.net.URI
-
 import com.adform.streamloader.batch.{RecordBatchingSink, RecordFormatter}
 import com.adform.streamloader.encoding.csv.CsvFileBuilderFactory
 import com.adform.streamloader.file.FileCommitStrategy.ReachedAnyOf
 import com.adform.streamloader.file._
+import com.adform.streamloader.model.Timestamp
 import com.adform.streamloader.s3.S3FileStorage
 import com.adform.streamloader.util.ConfigExtensions._
 import com.adform.streamloader.{KafkaSource, Loader, StreamLoader}
@@ -22,6 +21,9 @@ import org.apache.kafka.common.TopicPartition
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+
+import java.net.URI
+import java.time.LocalDate
 
 class BaseS3Loader extends Loader {
 
@@ -64,11 +66,15 @@ class BaseS3Loader extends Loader {
       RecordBatchingSink
         .builder()
         .recordBatcher(
-          FileRecordBatcher
+          PartitioningFileRecordBatcher
             .builder()
             .recordFormatter(recordFormatter)
+            .recordPartitioner((r, _) => Timestamp(r.consumerRecord.timestamp()).toDate)
             .fileBuilderFactory(new CsvFileBuilderFactory(Compression.NONE))
-            .fileCommitStrategy(ReachedAnyOf(recordsWritten = Some(cfg.getLong("file.max.records"))))
+            .fileCommitStrategy(
+              MultiFileCommitStrategy.anyFile(
+                ReachedAnyOf(recordsWritten = Some(cfg.getLong("file.max.records")))
+              ))
             .build()
         )
         .batchStorage(
@@ -77,7 +83,7 @@ class BaseS3Loader extends Loader {
             .s3Client(s3Client)
             .bucket(cfg.getString("s3.bucket"))
             .filePathFormatter(
-              new TimePartitioningFilePathFormatter(cfg.getStringOpt("file.time-partition.pattern"), None)
+              new TimePartitioningFilePathFormatter[LocalDate](cfg.getStringOpt("file.time-partition.pattern"), None)
             )
             .build()
         )

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileBatcher.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileBatcher.scala
@@ -53,7 +53,7 @@ case class ExternalOffsetVerticaFileRecordBatch(
   *
   * @tparam R Type of records written to files.
   */
-class ExternalOffsetVerticaFileBatcher[R] protected (
+class ExternalOffsetVerticaFileBatcher[R](
     dbDataSource: DataSource,
     fileIdSequence: String,
     recordFormatter: (Long, Record) => Seq[R],

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileStorage.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileStorage.scala
@@ -44,7 +44,7 @@ import scala.util.Using
   * Thus while it does not cost much to store the topic name, partition and offset next to each row physically (this data
   * compresses very well), it can be significant when auditing data usage for licensing.
   */
-class ExternalOffsetVerticaFileStorage protected (
+class ExternalOffsetVerticaFileStorage(
     dbDataSource: DataSource,
     table: String,
     offsetTable: String,

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileBatcher.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileBatcher.scala
@@ -30,7 +30,7 @@ case class InRowOffsetVerticaFileRecordBatch(
   *
   * @tparam R Type of records being written to files.
   */
-class InRowOffsetVerticaFileRecordBatcher[R] protected (
+class InRowOffsetVerticaFileRecordBatcher[R](
     recordFormatter: RecordFormatter[R],
     fileBuilderFactory: VerticaFileBuilderFactory[R],
     fileCommitStrategy: FileCommitStrategy,

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileStorage.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileStorage.scala
@@ -27,7 +27,7 @@ import scala.util.Using
   * thus storing the topic, partition and offset next to each row might be very expensive licensing-wise.
   * For a cheaper alternative see the [[ExternalOffsetVerticaFileStorage]].
   */
-class InRowOffsetVerticaFileStorage protected (
+class InRowOffsetVerticaFileStorage(
     dbDataSource: DataSource,
     table: String,
     topicColumnName: String,


### PR DESCRIPTION
Currently all file stores are single-file based, i.e. batches of records are consumed and committed sequentially as single files. This is enough for database backed stores, such as Vertica or ClickHouse, however for stores like S3/HDFS one might want to additionally partition files by e.g. date so that they get placed into directories like `dt=2020-01-01` etc, or by some other property, such as country or client. Up to now the only supported partitioning was record watermark based, i.e. given a batch of records one could format a file path using the watermarks of the batch, e.g. take the max watermark of the record range and use that as the date, however this is only approximately correct as a batch might contain records from multiple days.

This PR introduces a `PartitioningFileRecordBatcher` that constructs multi-file record batches by mapping records to different files based on some partitioning strategy defined by an instance of `RecordPartitioner`. Both S3 and HDFS stores now commit `PartitionedFileRecordBatch` instances that contain multiple files, their two-phase commit staging information is changed accordingly. The delivery guarantees for these stores remain exactly-once, as they still commit ranges of records sequentially, however they do that by uploading multiple files, meaning that they are no longer atomic and might leave gaps in records offsets during crashes, which would get filled during recovery.

Other changes in PR:
 - remove `protected` modifier from constructors
 - bump versions
 - check sbt scala style in CI