### PR TITLE
Implement batch discarding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,10 @@ jobs:
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
 
     - name: Setup JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: '11'
 
     - name: Run Tests
       run: sbt -Dsbt.color=always -Dsbt.supershell=false scalafmtCheck scalafmtSbtCheck headerCheckAll test it:test

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "stream-loader"
 
 ThisBuild / organization := "com.adform"
 ThisBuild / organizationName := "Adform"
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.8"
 ThisBuild / scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-target:jvm-1.8")
 
 ThisBuild / startYear := Some(2020)
@@ -20,9 +20,9 @@ ThisBuild / useCoursier := false
 val gitRepo = "git@github.com:adform/stream-loader.git"
 val gitRepoUrl = "https://github.com/adform/stream-loader"
 
-val scalaTestVersion = "3.2.9"
+val scalaTestVersion = "3.2.10"
 val scalaCheckVersion = "1.15.4"
-val scalaCheckTestVersion = "3.2.9.0"
+val scalaCheckTestVersion = "3.2.10.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -33,19 +33,19 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"    % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"  % "kafka-clients"     % "2.8.0",
+      "org.apache.kafka"  % "kafka-clients"     % "3.0.0",
       "org.log4s"         %% "log4s"            % "1.10.0",
       "org.anarres.lzo"   % "lzo-commons"       % "1.0.6",
       "org.xerial.snappy" % "snappy-java"       % "1.1.8.4",
-      "org.lz4"           % "lz4-java"          % "1.7.1",
-      "com.github.luben"  % "zstd-jni"          % "1.5.0-2",
+      "org.lz4"           % "lz4-java"          % "1.8.0",
+      "com.github.luben"  % "zstd-jni"          % "1.5.1-1",
       "com.univocity"     % "univocity-parsers" % "2.9.1",
-      "org.json4s"        %% "json4s-native"    % "4.0.0",
-      "io.micrometer"     % "micrometer-core"   % "1.7.0",
+      "org.json4s"        %% "json4s-native"    % "4.0.3",
+      "io.micrometer"     % "micrometer-core"   % "1.8.2",
       "org.scalatest"     %% "scalatest"        % scalaTestVersion % "test",
       "org.scalatestplus" %% "scalacheck-1-15"  % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"       % scalaCheckVersion % "test",
-      "ch.qos.logback"    % "logback-classic"   % "1.2.3" % "test"
+      "ch.qos.logback"    % "logback-classic"   % "1.2.10" % "test"
     ),
     testOptions += sbt.Tests.Setup(
       cl =>
@@ -69,7 +69,7 @@ lazy val `stream-loader-clickhouse` = project
     )
   )
 
-val parquetVersion = "1.12.0"
+val parquetVersion = "1.12.2"
 
 lazy val `stream-loader-hadoop` = project
   .in(file("stream-loader-hadoop"))
@@ -77,10 +77,10 @@ lazy val `stream-loader-hadoop` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.sksamuel.avro4s" %% "avro4s-core"     % "4.0.9",
+      "com.sksamuel.avro4s" %% "avro4s-core"     % "4.0.12",
       "org.apache.parquet"  % "parquet-avro"     % parquetVersion,
       "org.apache.parquet"  % "parquet-protobuf" % parquetVersion,
-      "org.apache.hadoop"   % "hadoop-client"    % "3.2.2" exclude ("log4j", "log4j"),
+      "org.apache.hadoop"   % "hadoop-client"    % "3.3.1" exclude ("log4j", "log4j"),
       "org.scalatest"       %% "scalatest"       % scalaTestVersion % "test"
     )
   )
@@ -91,10 +91,10 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.16.86",
+      "software.amazon.awssdk" % "s3"              % "2.17.114",
       "org.scalatest"          %% "scalatest"      % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.8" % "test",
-      "org.gaul"               % "s3proxy"         % "1.8.0" % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.143" % "test",
+      "org.gaul"               % "s3proxy"         % "1.9.0" % "test",
     )
   )
 
@@ -134,8 +134,8 @@ lazy val `stream-loader-tests` = project
   .settings(
     libraryDependencies ++= Seq(
       "com.typesafe"      % "config"           % "1.4.1",
-      "ch.qos.logback"    % "logback-classic"  % "1.2.3",
-      "com.zaxxer"        % "HikariCP"         % "4.0.3",
+      "ch.qos.logback"    % "logback-classic"  % "1.2.10",
+      "com.zaxxer"        % "HikariCP"         % "5.0.1",
       "com.vertica"       % "vertica-jdbc"     % verticaVersion from verticaJarUrl,
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion,
       "org.scalatest"     %% "scalatest"       % scalaTestVersion % "test,it",
@@ -172,7 +172,7 @@ lazy val `stream-loader-tests` = project
       val bin = s"/opt/${name.value}/bin/"
 
       new Dockerfile {
-        from("adoptopenjdk:11.0.11_9-jre-hotspot")
+        from("eclipse-temurin:11.0.13_8-jre")
 
         env("APP_CLASS_PATH" -> s"$lib/*")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.2")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.14")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
@@ -14,10 +14,10 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2021.4"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2022.0"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSinker.scala
@@ -76,6 +76,10 @@ class RecordBatchingSinker[B <: RecordBatch](
           retryOnFailureIf(retryPolicy)(!batchCommittedAfterFailure(batch)) {
             batchStorage.commitBatch(batch)
         })
+        if (!batch.discard()) {
+          log.warn("Failed discarding batch")
+        }
+
       } catch {
         case e if isInterruptionException(e) =>
           log.debug("Batch commit thread interrupted")

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/FileRecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/FileRecordBatch.scala
@@ -17,6 +17,8 @@ import com.adform.streamloader.model.{RecordBatch, RecordRange}
   */
 trait BaseFileRecordBatch extends RecordBatch {
   val file: File
+
+  override def discard(): Boolean = file.delete()
 }
 
 case class FileRecordBatch(file: File, recordRanges: Seq[RecordRange]) extends BaseFileRecordBatch

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitionedFileRecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/file/PartitionedFileRecordBatch.scala
@@ -31,4 +31,6 @@ case class PartitionedFileRecordBatch[P, +B <: BaseFileRecordBatch](partitionBat
       }
       .toSeq
   }
+
+  final override def discard(): Boolean = fileBatches.forall(_.discard())
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/model/RecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/model/RecordBatch.scala
@@ -21,6 +21,13 @@ trait RecordBatch {
     * Gets the ranges of records in each topic partition contained in the batch.
     */
   def recordRanges: Seq[RecordRange]
+
+  /**
+    * Performs any necessary cleanup after the batch is no longer needed, e.g. deletes any underlying files.
+    *
+    * @return Whether the discard operation succeeded.
+    */
+  def discard(): Boolean
 }
 
 /**

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/util/KafkaMetricsReporter.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/util/KafkaMetricsReporter.scala
@@ -39,7 +39,7 @@ class KafkaMetricsReporter extends MetricsReporter with Metrics {
     // which does happen with Kafka, e.g. it measures "records-lag-max" per per topic, but also per partition,
     // so we make metric names unique by appending all tag keys to the name except "client-id".
     val tagKeys = metric.metricName().tags().asScala.keys.toList.filter(_ != "client-id").sorted.mkString(".")
-    val tagPostfix = if (tagKeys.length > 0) s".by.$tagKeys" else ""
+    val tagPostfix = if (tagKeys.nonEmpty) s".by.$tagKeys" else ""
     val group = metric.metricName().group()
     val name = metric.metricName().name()
     s"kafka.$group.$name$tagPostfix"
@@ -81,7 +81,6 @@ class KafkaMetricsReporter extends MetricsReporter with Metrics {
 
   def zeroMetric(mn: MetricName): Metric = new Metric {
     override def metricName(): MetricName = mn
-    override def value(): Double = 0d
     override def metricValue(): Object = java.lang.Double.valueOf(0)
   }
 

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/batch/RecordBatchingSinkerTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/batch/RecordBatchingSinkerTest.scala
@@ -20,13 +20,29 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.util.Optional
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
 
   type Record = ConsumerRecord[Array[Byte], Array[Byte]]
 
-  case class TestBatch(recordRanges: Seq[RecordRange]) extends RecordBatch
+  case class TestBatch(recordRanges: Seq[RecordRange], var isDiscarded: Boolean) extends RecordBatch {
+    override def discard(): Boolean = {
+      isDiscarded = true
+      true
+    }
+  }
+
+  class TestBatchProvider {
+    val batches: mutable.ListBuffer[TestBatch] = mutable.ListBuffer.empty
+
+    def newBatch(recordRanges: Seq[RecordRange]): TestBatch = {
+      val batch = TestBatch(recordRanges, isDiscarded = false)
+      batches.addOne(batch)
+      batch
+    }
+  }
 
   val tp = new TopicPartition("test-topic", 0)
   val recordsPerBatch = 10
@@ -42,8 +58,7 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
       partition: Int,
       initialTimestamp: Long,
       initialOffset: Int,
-      recordCount: Int
-  ): Seq[Record] =
+      recordCount: Int): Seq[Record] =
     for (offset <- initialOffset until (initialOffset + recordCount))
       yield
         new Record(
@@ -63,7 +78,9 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
   def createTestRecords(initialTimestamp: Long): Seq[Record] =
     createRecords(tp.topic(), tp.partition(), initialTimestamp, initialOffset = 0, recordsPerBatch * batchCount)
 
-  def newAssertiveSinker(shouldUpdateWatermark: Boolean): RecordBatchingSinker[TestBatch] = {
+  def newAssertiveSinker(
+      shouldUpdateWatermark: Boolean,
+      batchProvider: TestBatchProvider = new TestBatchProvider): RecordBatchingSinker[TestBatch] = {
     var maxTimestamp = Timestamp(-1L)
 
     val sinker: RecordBatchingSinker[TestBatch] =
@@ -73,13 +90,17 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
         () =>
           new RecordBatchBuilder[TestBatch] {
             override def isBatchReady: Boolean = currentRecordCount >= recordsPerBatch
-            override def build(): Option[TestBatch] = Some(TestBatch(currentRecordRanges))
+
+            override def build(): Option[TestBatch] = Some(batchProvider.newBatch(currentRecordRanges))
+
             override def discard(): Unit = {}
         },
         new RecordBatchStorage[TestBatch] {
           override def recover(topicPartitions: Set[TopicPartition]): Unit = {}
+
           override def committedPositions(
               topicPartitions: Set[TopicPartition]): Map[TopicPartition, Option[StreamPosition]] = Map(tp -> None)
+
           override def commitBatch(batch: TestBatch): Unit = {
             val watermark = batch.recordRanges.head.end.watermark
             if (shouldUpdateWatermark) {
@@ -107,5 +128,14 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
   it("should not update watermark if record timestamp is greater but exceeds permitted time window") {
     val sinker = newAssertiveSinker(shouldUpdateWatermark = false)
     createTestRecords(nonValidTimestampMillis).foreach(sinker.write)
+  }
+
+  it("should discard all batches after committing them") {
+    val batchProvider = new TestBatchProvider
+    val sinker = newAssertiveSinker(shouldUpdateWatermark = true, batchProvider)
+
+    createTestRecords(validTimestampMillis).foreach(sinker.write)
+
+    batchProvider.batches.forall(_.isDiscarded) shouldBe true
   }
 }

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/batch/RecordBatchingSinkerTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/batch/RecordBatchingSinkerTest.scala
@@ -14,10 +14,12 @@ import com.adform.streamloader.model._
 import com.adform.streamloader.util.Retry
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.record.TimestampType
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.Optional
 import scala.concurrent.duration._
 
 class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
@@ -50,11 +52,12 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
           offset,
           initialTimestamp + offset * 1000,
           TimestampType.CREATE_TIME,
-          ConsumerRecord.NULL_CHECKSUM,
           ConsumerRecord.NULL_SIZE,
           ConsumerRecord.NULL_SIZE,
           Array.emptyByteArray,
-          Array.emptyByteArray
+          Array.emptyByteArray,
+          new RecordHeaders,
+          Optional.empty[Integer]
         )
 
   def createTestRecords(initialTimestamp: Long): Seq[Record] =

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
@@ -11,12 +11,14 @@ package com.adform.streamloader.file
 import com.adform.streamloader.encoding.csv.CsvFileBuilderFactory
 import com.adform.streamloader.model.{Record, RecordRange, StreamPosition, Timestamp}
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.record.TimestampType
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.File
 import java.nio.file.Files
+import java.util.Optional
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
@@ -114,9 +116,10 @@ class PartitioningFileRecordBatcherTest extends AnyFunSpec with Matchers {
       TimestampType.CREATE_TIME,
       -1,
       -1,
-      -1,
       key.getBytes("UTF-8"),
-      value.getBytes("UTF-8")
+      value.getBytes("UTF-8"),
+      new RecordHeaders,
+      Optional.empty[Integer]
     )
     Record(cr, timestamp)
   }

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/file/PartitioningFileRecordBatcherTest.scala
@@ -99,6 +99,22 @@ class PartitioningFileRecordBatcherTest extends AnyFunSpec with Matchers {
         partitionedBatch.get.partitionBatches.size shouldEqual 1
       }
     }
+
+    describe("cleanup") {
+
+      val builder = batcher.newBatchBuilder()
+      for (i <- 0 until 100) {
+        builder.add(newRecord("topic", 0, Timestamp(i), i, "key", "1"))
+      }
+      val batch = builder.build().get
+      val files = batch.fileBatches.map(_.file)
+
+      batch.discard()
+
+      it("should delete all files after discarding batch") {
+        files.exists(_.exists()) shouldBe false
+      }
+    }
   }
 
   def newRecord(

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:21.6.4.26")
+case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:22.1.2.2")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2021-06-17T00-10-46Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2022-01-07T01-53-23Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {


### PR DESCRIPTION
During the [refactoring](https://github.com/adform/stream-loader/pull/8/files) from file batches to abstract record batches the file delete functionality was removed ([this part](https://github.com/adform/stream-loader/pull/8/files#diff-cb661d321e494e50914b29b48655ece6ee7a728d5ddfd3fc931c4f149bff7da7L82-L84)), so now the loaders keep producing files under `/tmp` indefinitely.

We now introduce a `discard` method on a `RecordBatch` that is called after a successful commit to storage. The current file based batches implement it as file deletion.

Also, bump all versions and use JDK 11 during the build, as the latest Hikari version only works with JDK 11.