### PR TITLE
Add batcher close hook, allow subscribing to topic pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,4 @@ jobs:
         java-version: '11'
 
     - name: Run Tests
-      run: sbt -Dsbt.color=always -Dsbt.supershell=false scalafmtCheck scalafmtSbtCheck headerCheckAll test it:test
+      run: sbt -Dsbt.color=always -Dsbt.supershell=false scalafmtCheck scalafmtSbtCheck headerCheckAll test IntegrationTest/test

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ ThisBuild / useCoursier := false
 val gitRepo = "git@github.com:adform/stream-loader.git"
 val gitRepoUrl = "https://github.com/adform/stream-loader"
 
-val scalaTestVersion = "3.2.11"
-val scalaCheckVersion = "1.15.4"
-val scalaCheckTestVersion = "3.2.11.0"
+val scalaTestVersion = "3.2.12"
+val scalaCheckVersion = "1.16.0"
+val scalaCheckTestVersion = "3.2.12.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -33,17 +33,17 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"    % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"  % "kafka-clients"     % "3.1.0",
+      "org.apache.kafka"  % "kafka-clients"     % "3.2.0",
       "org.log4s"         %% "log4s"            % "1.10.0",
       "org.anarres.lzo"   % "lzo-commons"       % "1.0.6",
       "org.xerial.snappy" % "snappy-java"       % "1.1.8.4",
       "org.lz4"           % "lz4-java"          % "1.8.0",
-      "com.github.luben"  % "zstd-jni"          % "1.5.2-2",
+      "com.github.luben"  % "zstd-jni"          % "1.5.2-3",
       "com.univocity"     % "univocity-parsers" % "2.9.1",
-      "org.json4s"        %% "json4s-native"    % "4.0.4",
-      "io.micrometer"     % "micrometer-core"   % "1.8.4",
+      "org.json4s"        %% "json4s-native"    % "4.0.5",
+      "io.micrometer"     % "micrometer-core"   % "1.9.0",
       "org.scalatest"     %% "scalatest"        % scalaTestVersion % "test",
-      "org.scalatestplus" %% "scalacheck-1-15"  % scalaCheckTestVersion % "test",
+      "org.scalatestplus" %% "scalacheck-1-16"  % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"       % scalaCheckVersion % "test",
       "ch.qos.logback"    % "logback-classic"   % "1.2.11" % "test"
     ),
@@ -64,7 +64,7 @@ lazy val `stream-loader-clickhouse` = project
     libraryDependencies ++= Seq(
       "ru.yandex.clickhouse" % "clickhouse-jdbc"  % "0.3.1",
       "org.scalatest"        %% "scalatest"       % scalaTestVersion % "test",
-      "org.scalatestplus"    %% "scalacheck-1-15" % scalaCheckTestVersion % "test",
+      "org.scalatestplus"    %% "scalacheck-1-16" % scalaCheckTestVersion % "test",
       "org.scalacheck"       %% "scalacheck"      % scalaCheckVersion % "test"
     )
   )
@@ -77,7 +77,7 @@ lazy val `stream-loader-hadoop` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.sksamuel.avro4s" %% "avro4s-core"     % "4.0.12",
+      "com.sksamuel.avro4s" %% "avro4s-core"     % "4.0.13",
       "org.apache.parquet"  % "parquet-avro"     % parquetVersion,
       "org.apache.parquet"  % "parquet-protobuf" % parquetVersion,
       "org.apache.hadoop"   % "hadoop-client"    % "3.3.1" exclude ("log4j", "log4j"),
@@ -91,10 +91,10 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.17.151",
+      "software.amazon.awssdk" % "s3"              % "2.17.192",
       "org.scalatest"          %% "scalatest"      % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.180" % "test",
-      "org.gaul"               % "s3proxy"         % "1.9.0" % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.221" % "test",
+      "org.gaul"               % "s3proxy"         % "2.0.0" % "test",
     )
   )
 
@@ -109,7 +109,7 @@ lazy val `stream-loader-vertica` = project
     libraryDependencies ++= Seq(
       (("com.vertica"     % "vertica-jdbc"     % verticaVersion) from verticaJarUrl) % "provided",
       "org.scalatest"     %% "scalatest"       % scalaTestVersion                    % "test",
-      "org.scalatestplus" %% "scalacheck-1-15" % scalaCheckTestVersion               % "test",
+      "org.scalatestplus" %% "scalacheck-1-16" % scalaCheckTestVersion               % "test",
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion                   % "test"
     )
   )
@@ -139,7 +139,7 @@ lazy val `stream-loader-tests` = project
       "com.vertica"       % "vertica-jdbc"     % verticaVersion from verticaJarUrl,
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion,
       "org.scalatest"     %% "scalatest"       % scalaTestVersion % "test,it",
-      "org.scalatestplus" %% "scalacheck-1-15" % scalaCheckTestVersion % "test,it",
+      "org.scalatestplus" %% "scalacheck-1-16" % scalaCheckTestVersion % "test,it",
       ("com.spotify"      % "docker-client"    % "8.16.0" classifier "shaded") % "it"
     ),
     test := {}, // only integration tests present
@@ -172,7 +172,7 @@ lazy val `stream-loader-tests` = project
       val bin = s"/opt/${name.value}/bin/"
 
       new Dockerfile {
-        from("eclipse-temurin:11.0.14.1_1-jre")
+        from("eclipse-temurin:11.0.15_10-jre")
 
         env("APP_CLASS_PATH" -> s"$lib/*")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,16 +8,16 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.5")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2022.2"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2022.5"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.11")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatcher.scala
@@ -21,4 +21,9 @@ trait RecordBatcher[+B <: RecordBatch] {
     * Gets a new record batch builder.
     */
   def newBatchBuilder(): RecordBatchBuilder[B]
+
+  /**
+    * Closes the batcher.
+    */
+  def close(): Unit = {}
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSinker.scala
@@ -176,6 +176,7 @@ class RecordBatchingSinker[B <: RecordBatch](
   override def close(): Unit = if (isRunning.compareAndSet(true, false)) {
     log.info(s"Closing partition loader for '$groupName', discarding the current batch")
     builder.discard()
+    recordBatcher.close()
 
     log.debug("Interrupting batch commit thread and waiting for it to stop")
     commitThread.interrupt()

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "yandex/clickhouse-server:22.1.2.2")
+case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.4.5.9")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2022-01-07T01-53-23Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2022-05-08T23-50-31Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {


### PR DESCRIPTION
 - added `close()` to the `RecordBatcher` interface
 - added ability to subscribe to a `Pattern` of Kafka topics
 - bumped all versions