### PR TITLE
Fix partition assignment bug

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupingSink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupingSink.scala
@@ -76,11 +76,12 @@ abstract class PartitionGroupingSink extends Sink with Logging {
             s"newly assigned partitions ${groupPartitions
               .mkString(", ")} and previously owned partitions ${oldGroupPartitions.mkString(", ")}")
 
-        val sinker = sinkerForPartitionGroup(group, groupPartitions ++ oldGroupPartitions)
+        val newGroupPartitions = groupPartitions ++ oldGroupPartitions
+        val sinker = sinkerForPartitionGroup(group, newGroupPartitions)
         val positions = sinker.initialize(kafkaContext)
 
-        partitionGroups.put(group, groupPartitions -> sinker)
-        groupPartitions.foreach(tp => partitionSinkers.put(tp, sinker))
+        partitionGroups.put(group, newGroupPartitions -> sinker)
+        newGroupPartitions.foreach(tp => partitionSinkers.put(tp, sinker))
         positions
     }
 


### PR DESCRIPTION
The partition grouping sink had a bug where it would miss previously assigned partitions if new partitions to the existing group got assigned. E.g. consider a sink that groups by topic, which gets assigned partitions `(test, 0)` and `(test, 1)`. It would create a single group `test` and assign partitions `0` and `1` to it. If it now got assigned `(test, 2)` the sink would destroy the existing group and create a new one with the partition `2` only, missing the previously assigned partitions `0` and `1`.

The bug would cause loaders to crash with a `NoSuchElementException` exception [here](https://github.com/adform/stream-loader/blob/4f2257b98678df54455ed2623cae353fa209d2d1/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupingSink.scala#L139). I suspect we never encountered it in production because the Kafka client always revokes partitions before assigning them again and never does a partial assignment. It may happen if the partition count for a topic gets increased, but I'm also not sure.