### PR TITLE
Move watermark tracking to source

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaSource.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/KafkaSource.scala
@@ -8,15 +8,18 @@
 
 package com.adform.streamloader
 
+import com.adform.streamloader.model.{Record, StreamPosition, Timestamp}
+import com.adform.streamloader.util.{MetricTag, Metrics}
+import io.micrometer.core.instrument.Gauge
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRebalanceListener, KafkaConsumer}
+import org.apache.kafka.common.TopicPartition
+
 import java.time.Duration
+import java.util
 import java.util.Properties
 import java.util.concurrent.locks.ReentrantLock
 import java.util.regex.Pattern
-
-import com.adform.streamloader.model.StreamPosition
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer}
-import org.apache.kafka.common.TopicPartition
-
+import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters._
 
 /**
@@ -27,8 +30,16 @@ import scala.jdk.CollectionConverters._
   * @param consumerProperties Kafka consumer properties to use.
   * @param topics Topics to subscribe to, either a list or a pattern of topics.
   * @param pollTimeout Timeout when polling data from Kafka.
+  * @param watermarkProviderFactory Factory for constructing watermark providers.
   */
-class KafkaSource(consumerProperties: Properties, topics: Either[Seq[String], Pattern], pollTimeout: Duration) {
+class KafkaSource(
+    consumerProperties: Properties,
+    topics: Either[Seq[String], Pattern],
+    pollTimeout: Duration,
+    watermarkProviderFactory: () => WatermarkProvider)
+    extends Metrics {
+
+  override protected def metricsRoot: String = "stream_loader.source"
 
   private val props = new Properties()
 
@@ -39,6 +50,9 @@ class KafkaSource(consumerProperties: Properties, topics: Either[Seq[String], Pa
 
   private var consumerLock: ReentrantLock = _
   private var consumer: KafkaConsumer[Array[Byte], Array[Byte]] = _
+
+  private val watermarkProviders: TrieMap[TopicPartition, WatermarkProvider] = TrieMap.empty
+  private val watermarkMetricGauges: TrieMap[TopicPartition, Gauge] = TrieMap.empty
 
   private def withLock[T](code: => T): T = {
     consumerLock.lockInterruptibly()
@@ -68,9 +82,29 @@ class KafkaSource(consumerProperties: Properties, topics: Either[Seq[String], Pa
     */
   def subscribe(listener: ConsumerRebalanceListener): Unit = {
     // do not lock as this is invoked during poll, so would result in a deadlock
+
+    val initializingListener = new ConsumerRebalanceListener {
+      override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
+        partitions.forEach(tp => {
+          watermarkProviders.remove(tp)
+          watermarkMetricGauges.remove(tp).foreach(_.close())
+        })
+        listener.onPartitionsRevoked(partitions)
+      }
+
+      override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+        partitions.forEach(tp => {
+          val watermarkProvider = watermarkProviderFactory()
+          watermarkProviders.addOne(tp -> watermarkProvider)
+          watermarkMetricGauges.addOne(tp -> Metrics.watermarkGauge(tp, watermarkProvider))
+        })
+        listener.onPartitionsAssigned(partitions)
+      }
+    }
+
     topics match {
-      case Left(tp) => consumer.subscribe(tp.asJava, listener)
-      case Right(pt) => consumer.subscribe(pt, listener)
+      case Left(tp) => consumer.subscribe(tp.asJava, initializingListener)
+      case Right(pt) => consumer.subscribe(pt, initializingListener)
     }
   }
 
@@ -82,6 +116,7 @@ class KafkaSource(consumerProperties: Properties, topics: Either[Seq[String], Pa
     */
   def seek(partition: TopicPartition, position: StreamPosition): Unit = {
     // do not lock as this can be invoked during poll on a rebalance, so would result in a deadlock
+    watermarkProviders(partition).initialize(position.watermark)
     consumer.seek(partition, position.offset)
   }
 
@@ -90,16 +125,39 @@ class KafkaSource(consumerProperties: Properties, topics: Either[Seq[String], Pa
     *
     * @return An iterator of polled records.
     */
-  def poll(): Iterable[ConsumerRecord[Array[Byte], Array[Byte]]] = withLock {
+  def poll(): Iterable[Record] = withLock {
     // loaders can commit offsets in the background, so take a lock on the consumer
-    consumer.poll(pollTimeout).asScala
+    consumer
+      .poll(pollTimeout)
+      .asScala
+      .map(consumerRecord => {
+        val partition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition())
+        val watermark = watermarkProviders(partition).observeEvent(Timestamp(consumerRecord.timestamp()))
+        Record(consumerRecord, watermark)
+      })
   }
 
   /**
-    * Closes the Kafka consumer.
+    * Closes the source and all underlying resources.
     */
   def close(): Unit = withLock {
     consumer.close()
+  }
+
+  private object Metrics {
+
+    private val commonTags = Seq(
+      MetricTag("loader-thread", Thread.currentThread().getName)
+    )
+    private def partitionTags(tp: TopicPartition) =
+      Seq(MetricTag("topic", tp.topic()), MetricTag("partition", tp.partition().toString))
+
+    def watermarkGauge(partition: TopicPartition, watermarkProvider: WatermarkProvider): Gauge =
+      createGauge(
+        "watermark.ms",
+        watermarkProvider,
+        (p: WatermarkProvider) => p.currentWatermark.millis.toDouble,
+        commonTags ++ partitionTags(partition))
   }
 }
 
@@ -107,15 +165,24 @@ object KafkaSource {
   case class Builder(
       private val _consumerProperties: Properties,
       private val _topics: Either[Seq[String], Pattern],
-      private val _pollTimeout: Duration) {
+      private val _pollTimeout: Duration,
+      private val _watermarkProviderFactory: () => WatermarkProvider) {
 
     def consumerProperties(props: Properties): Builder = copy(_consumerProperties = props)
     def topics(topics: Seq[String]): Builder = copy(_topics = Left(topics))
     def topics(pattern: Pattern): Builder = copy(_topics = Right(pattern))
     def pollTimeout(timeout: Duration): Builder = copy(_pollTimeout = timeout)
 
-    def build(): KafkaSource = new KafkaSource(_consumerProperties, _topics, _pollTimeout)
+    def validWatermarkDiff(diff: Duration): Builder =
+      copy(_watermarkProviderFactory = () => new MaxWatermarkProvider(diff))
+
+    def build(): KafkaSource = new KafkaSource(_consumerProperties, _topics, _pollTimeout, _watermarkProviderFactory)
   }
 
-  def builder(): Builder = Builder(new Properties(), Left(Seq.empty), Duration.ofSeconds(1))
+  def builder(): Builder =
+    Builder(
+      new Properties(),
+      Left(Seq.empty),
+      Duration.ofSeconds(1),
+      () => new MaxWatermarkProvider(Duration.ofHours(1)))
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupSinker.scala
@@ -8,8 +8,7 @@
 
 package com.adform.streamloader
 
-import com.adform.streamloader.model.StreamPosition
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import com.adform.streamloader.model.{Record, StreamPosition}
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -42,12 +41,12 @@ trait PartitionGroupSinker {
   def initialize(kafkaContext: KafkaContext): Map[TopicPartition, Option[StreamPosition]]
 
   /**
-    * Writes a given Kafka record to storage.
+    * Writes a given stream record to storage.
     *
     * Calling this method does not ensure that the record will be flushed to storage,
     * e.g. the sinker might implement batching thus delaying the actual storage.
     */
-  def write(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit
+  def write(record: Record): Unit
 
   /**
     * Notifies the sinker that record consumption is still active.

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupingSink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/PartitionGroupingSink.scala
@@ -8,9 +8,8 @@
 
 package com.adform.streamloader
 
-import com.adform.streamloader.model.StreamPosition
+import com.adform.streamloader.model.{Record, StreamPosition}
 import com.adform.streamloader.util.Logging
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.concurrent.TrieMap
@@ -134,10 +133,10 @@ abstract class PartitionGroupingSink extends Sink with Logging {
   /**
     * Forwards a consumer record to the correct partition sinker.
     *
-    * @param record Kafka consumer record to write
+    * @param record Stream record to write.
     */
-  override def write(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
-    partitionSinkers(new TopicPartition(record.topic(), record.partition())).write(record)
+  override def write(record: Record): Unit = {
+    partitionSinkers(record.topicPartition).write(record)
   }
 
   /**

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/Sink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/Sink.scala
@@ -8,8 +8,7 @@
 
 package com.adform.streamloader
 
-import com.adform.streamloader.model.StreamPosition
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import com.adform.streamloader.model.{Record, StreamPosition}
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -52,9 +51,9 @@ trait Sink {
   /**
     * Writes a record to the underlying storage.
     *
-    * @param record Kafka consumer record to write
+    * @param record Stream record to write.
     */
-  def write(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit
+  def write(record: Record): Unit
 
   /**
     * Notifies the sink that record consumption is still active, called when no records get polled from Kafka.

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/WatermarkProvider.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/WatermarkProvider.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader
+
+import com.adform.streamloader.model.Timestamp
+import com.adform.streamloader.util.{Logging, TimeProvider}
+
+import java.time.Duration
+
+/**
+  * Trait for implementing watermark tracking in a stream.
+  */
+trait WatermarkProvider {
+
+  /**
+    * Initializes the provider to a specified watermark.
+    *
+    * @param initialWatermark The initial watermark to initialize to.
+    * @return The initial watermark.
+    */
+  def initialize(initialWatermark: Timestamp): Timestamp
+
+  /**
+    * Observes a new event and moves the watermark forward if needed.
+    *
+    * @param timestamp Timestamp of the new event.
+    * @return The current watermark.
+    */
+  def observeEvent(timestamp: Timestamp): Timestamp
+
+  /**
+    * Returns the current watermark.
+    */
+  def currentWatermark: Timestamp
+}
+
+/**
+  * Watermark provider that sets the watermark to the maximum observed event time.
+  * In order to protect from malformed messages with timestamps from the future, values greater than a predefined
+  * threshold above the current time are rejected and do not advance the watermark.
+  *
+  * @param validWatermarkDiff Upper limit for setting watermarks greater than the current time.
+  */
+class MaxWatermarkProvider(validWatermarkDiff: Duration)(implicit timeProvider: TimeProvider = TimeProvider.system)
+    extends WatermarkProvider
+    with Logging {
+
+  private val validWatermarkDiffMillis = validWatermarkDiff.toMillis
+  private var watermark = Timestamp(-1L)
+
+  def initialize(initialWatermark: Timestamp): Timestamp = {
+    watermark = initialWatermark
+    watermark
+  }
+
+  def observeEvent(timestamp: Timestamp): Timestamp = {
+    if (timestamp.millis <= timeProvider.currentMillis + validWatermarkDiffMillis) {
+      if (timestamp > watermark)
+        watermark = timestamp
+    } else {
+      log.warn(
+        s"Received a message with an out of bounds timestamp $timestamp (" + timestamp
+          .format("yyyy/MM/dd HH:mm:ss")
+          .get + "), ignoring and not advancing the watermark")
+    }
+    watermark
+  }
+
+  def currentWatermark: Timestamp = watermark
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/model/Record.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/model/Record.scala
@@ -9,6 +9,7 @@
 package com.adform.streamloader.model
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
 
 /**
   * A single record consumed from the source.
@@ -16,4 +17,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
   * @param consumerRecord The Kafka consumer record.
   * @param watermark The calculated watermark, i.e. the maximum timestamp seen.
   */
-case class Record(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], watermark: Timestamp)
+case class Record(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], watermark: Timestamp) {
+  def topicPartition: TopicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition())
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/MaxWatermarkProviderTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/MaxWatermarkProviderTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader
+
+import com.adform.streamloader.model.Timestamp
+import com.adform.streamloader.util.TimeProvider
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.Duration
+
+class MaxWatermarkProviderTest extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
+
+  class MockTimeProvider(var time: Long) extends TimeProvider {
+    override def currentMillis: Long = time
+  }
+
+  it("should advance the watermark when time advances") {
+    val wp = new MaxWatermarkProvider(Duration.ofHours(1))(new MockTimeProvider(0L))
+
+    wp.observeEvent(Timestamp(1L))
+    wp.currentWatermark shouldEqual Timestamp(1L)
+
+    wp.observeEvent(Timestamp(2L))
+    wp.currentWatermark shouldEqual Timestamp(2L)
+
+    wp.observeEvent(Timestamp(3L))
+    wp.currentWatermark shouldEqual Timestamp(3L)
+  }
+
+  it("should not change the watermark if late data arrives") {
+    val wp = new MaxWatermarkProvider(Duration.ofHours(1))(new MockTimeProvider(0L))
+
+    wp.observeEvent(Timestamp(10L))
+    wp.currentWatermark shouldEqual Timestamp(10L)
+
+    wp.observeEvent(Timestamp(2L))
+    wp.currentWatermark shouldEqual Timestamp(10L)
+
+    wp.observeEvent(Timestamp(3L))
+    wp.currentWatermark shouldEqual Timestamp(10L)
+
+    wp.observeEvent(Timestamp(11L))
+    wp.currentWatermark shouldEqual Timestamp(11L)
+  }
+
+  it("should not advance the watermark if timestamp crosses valid threshold") {
+    val tp = new MockTimeProvider(0L)
+    val wp = new MaxWatermarkProvider(Duration.ofMillis(100))(tp)
+
+    wp.observeEvent(Timestamp(1L))
+    wp.currentWatermark shouldEqual Timestamp(1L)
+
+    wp.observeEvent(Timestamp(101L))
+    wp.currentWatermark shouldEqual Timestamp(1L)
+
+    tp.time = 100L
+    wp.observeEvent(Timestamp(101L))
+    wp.currentWatermark shouldEqual Timestamp(101L)
+  }
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/PartitionGroupingSinkTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/PartitionGroupingSinkTest.scala
@@ -8,7 +8,7 @@
 
 package com.adform.streamloader
 
-import com.adform.streamloader.model.StreamPosition
+import com.adform.streamloader.model.{Record, StreamPosition, Timestamp}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.funspec.AnyFunSpec
@@ -30,8 +30,8 @@ class PartitionGroupingSinkTest extends AnyFunSpec with Matchers with ScalaCheck
         override val groupName: String = name
         override val groupPartitions: Set[TopicPartition] = partitions
         override def initialize(kc: KafkaContext): Map[TopicPartition, Option[StreamPosition]] = Map.empty
-        override def write(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
-          groupValuesWritten.addOne(name -> new String(record.value(), "UTF-8"))
+        override def write(record: Record): Unit = {
+          groupValuesWritten.addOne(name -> new String(record.consumerRecord.value(), "UTF-8"))
         }
         override def heartbeat(): Unit = {}
         override def close(): Unit = partitionSinkers.remove(this)
@@ -41,7 +41,10 @@ class PartitionGroupingSinkTest extends AnyFunSpec with Matchers with ScalaCheck
     }
 
     def writeValue(topic: String, partition: Int, value: String): Unit = {
-      write(new ConsumerRecord[Array[Byte], Array[Byte]](topic, partition, 0, Array.empty[Byte], value.getBytes("UTF-8")))
+      write(
+        Record(
+          new ConsumerRecord[Array[Byte], Array[Byte]](topic, partition, 0, Array.empty[Byte], value.getBytes("UTF-8")),
+          Timestamp(0L)))
     }
   }
 


### PR DESCRIPTION
Currently the `Source` and `Sink` interfaces are not symmetric in how they deal with watermarks, i.e. we have:
```scala
class KafkaSource {
  def seek(partition: TopicPartition, position: StreamPosition): Unit
  def poll(): Iterable[ConsumerRecord[Array[Byte], Array[Byte]]]
}
```
and
```scala
trait Sink {
  def assignPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, Option[StreamPosition]]
  def write(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit
}
```
where the `StreamPosition` includes the Kafka consumer record plus the watermark. The source currently produces raw Kafka records without watermarks, but sinks are required to return the committed offset together with a watermark - they both get passed down to the source when initializing, but the watermark is not used there, only the offset is used to seek to the initial position in the stream. Watermarks only get introduced in the `RecordBatchingSinker` class [here](https://github.com/adform/stream-loader/blob/5f0a0368577c38be20bae0ec3f40f53f7d643bc4/stream-loader-core/src/main/scala/com/adform/streamloader/batch/RecordBatchingSinker.scala#L125).

This approach has multiple issues:
 - watermarks are not available at the `Source` and `Sink` interfaces so it's not possible to implement generic wrapping implementations, e.g. a `DeduplicatingSource` that would keep a sliding window buffer based on the watermark,
 - any non-batching sinks would have to re-implement the watermark tracking logic,
 - watermark tracking is not customizable.

This PR moves out the watermark tracking to the `Source` so that the interfaces become:
```scala
class KafkaSource {
  def seek(partition: TopicPartition, position: StreamPosition): Unit
  def poll(): Iterable[Record]
}
```
and
```scala
trait Sink {
  def assignPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, Option[StreamPosition]]
  def write(record: Record): Unit
}
```
where `Record` is a tuple of consumer record and a watermark. The watermark tracking is now done at the `KafkaSource` and is fully customizable as a `WatermarkProvider` trait. The default `MaxWatermarkProvider` implementation replicates the current behavior of simply advancing the watermark based on the max time seen with a simple safeguard against records from the future.

The watermark tracking metric is now available as `stream_loader.source.watermark.ms`, which is the full actual watermark in milliseconds instead of the time difference as done before - the subtraction can be done when reporting.