### PR TITLE
Add a rewinding sinker implementation

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/model/StreamInterval.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/model/StreamInterval.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.model
+
+import java.time.Duration
+
+/**
+  * Represents an interval in a single stream partition. Can be either an offset interval, a watermark difference
+  * or some combination of both.
+  */
+sealed trait StreamInterval {
+  def isZero: Boolean
+}
+
+object StreamInterval {
+
+  /**
+    * Represents a fixed offset difference.
+    */
+  case class OffsetRange(offset: Long) extends StreamInterval {
+    override def isZero: Boolean = offset == 0
+  }
+
+  /**
+    * Represents a difference in terms of the watermark.
+    */
+  case class WatermarkRange(duration: Duration) extends StreamInterval {
+    override def isZero: Boolean = duration.isZero
+  }
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupSinker.scala
@@ -60,3 +60,23 @@ trait PartitionGroupSinker {
     */
   def close(): Unit
 }
+
+/**
+  * A [[PartitionGroupSinker]] that wraps another sinker instance and by default forwards all actions to it.
+  * Used for implementing other wrapper sinks in order to avoid boilerplate.
+  *
+  * @param basesSinker The base sinker to forward to.
+  */
+abstract class WrappedPartitionGroupSinker(basesSinker: PartitionGroupSinker) extends PartitionGroupSinker {
+
+  override val groupName: String = basesSinker.groupName
+  override val groupPartitions: Set[TopicPartition] = basesSinker.groupPartitions
+
+  override def initialize(kafkaContext: KafkaContext): Map[TopicPartition, Option[StreamPosition]] =
+    basesSinker.initialize(kafkaContext)
+
+  override def write(record: StreamRecord): Unit = basesSinker.write(record)
+  override def heartbeat(): Unit = basesSinker.heartbeat()
+
+  override def close(): Unit = basesSinker.close()
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupingSink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupingSink.scala
@@ -25,7 +25,7 @@ import scala.collection.concurrent.TrieMap
   * separate groups for smaller and larger topics, each group receiving a separate [[PartitionGroupSinker]].
   * E.g., if the sinker writes all data to a file, you would end up with separate files for smaller and larger topics.
   */
-abstract class PartitionGroupingSink extends Sink with Logging {
+trait PartitionGroupingSink extends Sink with Logging {
 
   private val partitionGroups = TrieMap[String, (Set[TopicPartition], PartitionGroupSinker)]()
   private val partitionSinkers = TrieMap[TopicPartition, PartitionGroupSinker]()

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/RewindingPartitionGroupSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/RewindingPartitionGroupSinker.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.sink
+
+import com.adform.streamloader.model.{StreamInterval, StreamPosition, StreamRecord, Timestamp}
+import com.adform.streamloader.source.KafkaContext
+import com.adform.streamloader.util.Logging
+import org.apache.kafka.common.TopicPartition
+
+import java.time.Duration
+import scala.collection.mutable
+
+/**
+  * A wrapper sinker that rewinds the streams back by a given interval during initialization.
+  * Can be used to implement stateful sinks that need to "warm-up" before starting actual writing, e.g. in order to
+  * implement record de-duplication one can rewind the streams in order to build-up a cache.
+  * Implementers need to override the method for "touching" rewound records, once the sinker catches up all new records
+  * are simply passed down to the base sinker.
+  *
+  * Rewinding by an offset range is straightforward as we simply subtract, a caveat here is that we can't determine the
+  * rewound watermark, so we retain it. Rewinding by watermark is done by calling offsetForTimes in Kafka, which
+  * can in principle return a result that is not exactly consistent with the watermark calculated by the stream loader.
+  * Either way the rewinding should be considered to be done on a best-effort basis.
+  *
+  * @param baseSinker A base sinker to wrap.
+  * @param rewindInterval A stream interval to rewind backwards.
+  */
+abstract class RewindingPartitionGroupSinker(baseSinker: PartitionGroupSinker, rewindInterval: StreamInterval)
+    extends WrappedPartitionGroupSinker(baseSinker)
+    with Logging {
+
+  private type Offsets = Map[TopicPartition, Option[StreamPosition]]
+
+  private var originalOffsets: Offsets = _
+
+  private val topicPartitionsFullyRewound: mutable.Map[TopicPartition, Boolean] = mutable.Map.empty
+  private var fullyRewound: Boolean = false
+
+  override def initialize(kafkaContext: KafkaContext): Map[TopicPartition, Option[StreamPosition]] = {
+    originalOffsets = super.initialize(kafkaContext)
+    if (rewindInterval.isZero) {
+      log.info(s"Rewind interval is zero, skipping rewinding and using original offsets $originalOffsets")
+      fullyRewound = true
+      originalOffsets
+    } else {
+      groupPartitions.foreach(tp => topicPartitionsFullyRewound.addOne(tp -> false))
+      val rewoundOffsets = rewindInterval match {
+        case StreamInterval.OffsetRange(diff) => rewindByOffset(originalOffsets, diff)
+        case StreamInterval.WatermarkRange(diff) => rewindByWatermark(originalOffsets, diff, kafkaContext)
+      }
+      log.info(s"Rewound original offsets $originalOffsets to $rewoundOffsets, warming up")
+      rewoundOffsets
+    }
+  }
+
+  private def rewindByOffset(offsets: Offsets, rewindBy: Long): Offsets = {
+    val rewound = offsets.map { case (tp, pos) =>
+      (tp, pos.map(p => p.copy(offset = Math.max(0, p.offset - rewindBy), p.watermark)))
+    }
+
+    log.debug(s"Translated offsets $offsets to $rewound by subtracting $rewindBy")
+    rewound
+  }
+
+  private def rewindByWatermark(offsets: Offsets, rewindBy: Duration, kafkaContext: KafkaContext): Offsets = {
+    val toLookup = offsets.collect {
+      case (tp, Some(StreamPosition(_, w))) if w.millis > 0 =>
+        (tp, Math.max(0, w.millis - rewindBy.toMillis))
+    }
+    val translated = kafkaContext.offsetsForTimes(toLookup)
+
+    log.debug(s"Kafka translated rewound watermark positions $toLookup to offsets $translated")
+    offsets.map { case (tp, _) =>
+      (tp, translated.get(tp).flatMap(_.map(ot => StreamPosition(ot.offset(), Timestamp(ot.timestamp())))))
+    }
+  }
+
+  /**
+    * Process a given stream record that is already written by the base sink, but is now rewound back
+    * during initialization for warm-up.
+    *
+    * @param record Stream record to "touch".
+    */
+  protected def touchRewoundRecord(record: StreamRecord): Unit
+
+  /**
+    * Checks whether the given record is a "rewound" record, i.e. is already committed by the base sink and if so
+    * only "touches" it, otherwise passes it further down to the base sink.
+    */
+  override def write(record: StreamRecord): Unit = {
+    if (fullyRewound || topicPartitionsFullyRewound(record.topicPartition)) {
+      super.write(record)
+    } else {
+      val isRewoundRecord = originalOffsets(record.topicPartition) match {
+        case Some(StreamPosition(committedOffset, _)) => record.consumerRecord.offset() < committedOffset
+        case _ => false
+      }
+      if (isRewoundRecord) {
+        touchRewoundRecord(record)
+      } else {
+        topicPartitionsFullyRewound(record.topicPartition) = true
+        log.info(s"Partition ${record.topicPartition} fully rewound")
+
+        if (topicPartitionsFullyRewound.forall { case (_, isRewound) => isRewound }) {
+          log.info("All partitions fully rewound")
+          fullyRewound = true
+        }
+
+        super.write(record)
+      }
+    }
+  }
+}

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/Sink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/Sink.scala
@@ -77,3 +77,24 @@ object Sink {
     def build(): Sink
   }
 }
+
+/**
+  * A [[Sink]] that wraps another sink instance and by default forwards all operations to it.
+  * Used for implementing concrete wrapping sinks in order to avoid boilerplate.
+  *
+  * @param baseSink The base sink to wrap.
+  * @tparam S Type of sink being wrapped.
+  */
+abstract class WrappedSink[S <: Sink](baseSink: S) extends Sink {
+  override def initialize(kafkaContext: KafkaContext): Unit = baseSink.initialize(kafkaContext)
+
+  override def assignPartitions(partitions: Set[TopicPartition]): Map[TopicPartition, Option[StreamPosition]] =
+    baseSink.assignPartitions(partitions)
+  override def revokePartitions(partitions: Set[TopicPartition]): Map[TopicPartition, Option[StreamPosition]] =
+    baseSink.revokePartitions(partitions)
+
+  override def write(record: StreamRecord): Unit = baseSink.write(record)
+  override def heartbeat(): Unit = baseSink.heartbeat()
+
+  override def close(): Unit = baseSink.close()
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/model/Generators.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/model/Generators.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.model
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.TimestampType
+
+import java.util.Optional
+
+object Generators {
+
+  def newStreamRecord(
+      topic: String,
+      partition: Int,
+      offset: Long,
+      timestamp: Timestamp,
+      key: String,
+      value: String
+  ): StreamRecord = {
+    val cr = new ConsumerRecord[Array[Byte], Array[Byte]](
+      topic,
+      partition,
+      offset,
+      timestamp.millis,
+      TimestampType.CREATE_TIME,
+      -1,
+      -1,
+      key.getBytes("UTF-8"),
+      value.getBytes("UTF-8"),
+      new RecordHeaders,
+      Optional.empty[Integer]
+    )
+    StreamRecord(cr, timestamp)
+  }
+
+  def newStreamRecord(
+      topic: String,
+      partition: Int,
+      offset: Long,
+      timestamp: Timestamp
+  ): StreamRecord = {
+    newStreamRecord(topic, partition, offset, timestamp, "", "")
+  }
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/sink/RewindingPartitionGroupSinkerTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/sink/RewindingPartitionGroupSinkerTest.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.sink
+
+import com.adform.streamloader.model.Generators._
+import com.adform.streamloader.model.StreamInterval._
+import com.adform.streamloader.model.{StreamInterval, StreamPosition, StreamRecord, Timestamp}
+import com.adform.streamloader.source.{KafkaContext, MockKafkaContext}
+import com.adform.streamloader.util.TestExtensions._
+import org.apache.kafka.common.TopicPartition
+import org.scalacheck.Gen
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.Duration
+import scala.collection.mutable
+
+class RewindingPartitionGroupSinkerTest extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
+
+  class TestBaseSinker(committedPositions: Map[TopicPartition, Option[StreamPosition]]) extends PartitionGroupSinker {
+
+    val writtenRecords: mutable.ArrayBuffer[StreamRecord] = mutable.ArrayBuffer.empty
+
+    override val groupName: String = "test-group"
+    override val groupPartitions: Set[TopicPartition] = committedPositions.keySet
+
+    override def initialize(kc: KafkaContext): Map[TopicPartition, Option[StreamPosition]] = {
+      writtenRecords.clear()
+      committedPositions
+    }
+
+    override def write(record: StreamRecord): Unit = writtenRecords.addOne(record)
+
+    override def heartbeat(): Unit = {}
+
+    override def close(): Unit = {}
+  }
+
+  class TestRewindingSinker(baseSinker: TestBaseSinker, interval: StreamInterval)
+      extends RewindingPartitionGroupSinker(baseSinker, interval) {
+
+    val touchedRecords: mutable.ArrayBuffer[StreamRecord] = mutable.ArrayBuffer.empty
+
+    override def initialize(kafkaContext: KafkaContext): Map[TopicPartition, Option[StreamPosition]] = {
+      val positions = super.initialize(kafkaContext)
+      touchedRecords.clear()
+      positions
+    }
+
+    override def touchRewoundRecord(record: StreamRecord): Unit = touchedRecords.addOne(record)
+  }
+
+  describe("rewinding sinker") {
+
+    val kafka = new MockKafkaContext()
+
+    val initRecords = Seq(
+      newStreamRecord("test", 0, 0L, Timestamp(0L)),
+      newStreamRecord("test", 0, 10L, Timestamp(100L)),
+      newStreamRecord("test", 0, 20L, Timestamp(90L)),
+      newStreamRecord("test", 0, 30L, Timestamp(200L)),
+      newStreamRecord("test", 1, 0L, Timestamp(0L)),
+      newStreamRecord("test", 1, 10L, Timestamp(100L)),
+      newStreamRecord("test", 1, 20L, Timestamp(300L))
+    )
+
+    initRecords.foreach(r => kafka.write(r))
+    val committedPositions = kafka.commitWrites() + (new TopicPartition("test", 2) -> None)
+
+    val baseSinker = new TestBaseSinker(committedPositions)
+
+    describe("rewind offset calculation with numeric ranges") {
+
+      it("should be a no-op with a zero offset") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, OffsetRange(0L))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(31L, Timestamp(200L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(21L, Timestamp(300L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+
+      it("should be correct with a valid offset") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, OffsetRange(10L))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(21L, Timestamp(200L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(11L, Timestamp(300L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+
+      it("should be capped given an offset that is out of range") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, OffsetRange(1000L))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(0L, Timestamp(200L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(0L, Timestamp(300L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+    }
+
+    describe("rewind offset calculation with watermark ranges") {
+      it("should be a no-op with a zero offset") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, WatermarkRange(Duration.ofMillis(0)))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(31L, Timestamp(200L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(21L, Timestamp(300L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+
+      it("should be correct with a valid offset") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, WatermarkRange(Duration.ofMillis(150L)))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(10L, Timestamp(100L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(20L, Timestamp(300L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+
+      it("should be capped given an offset that is out of range") {
+        val rewindingSinker = new TestRewindingSinker(baseSinker, WatermarkRange(Duration.ofHours(10)))
+
+        val rewound = rewindingSinker.initialize(kafka)
+
+        rewound should contain theSameElementsAs Map(
+          new TopicPartition("test", 0) -> Some(StreamPosition(0L, Timestamp(0L))),
+          new TopicPartition("test", 1) -> Some(StreamPosition(0L, Timestamp(0L))),
+          new TopicPartition("test", 2) -> None
+        )
+      }
+    }
+
+    describe(s"message writing") {
+      val rewindingSinker = new TestRewindingSinker(baseSinker, OffsetRange(100L))
+      rewindingSinker.initialize(kafka)
+
+      it("should touch and not write warm-up records") {
+        initRecords.foreach(r => rewindingSinker.write(r))
+
+        baseSinker.writtenRecords shouldBe empty
+        rewindingSinker.touchedRecords.map(_.tpo) should contain theSameElementsInOrderAs initRecords.map(_.tpo)
+      }
+
+      it("should pass through all new records afterwards") {
+        val records = Seq(
+          newStreamRecord("test", 0, 31L, Timestamp(220L)),
+          newStreamRecord("test", 0, 32L, Timestamp(219L)),
+          newStreamRecord("test", 1, 21L, Timestamp(299L)),
+          newStreamRecord("test", 1, 22L, Timestamp(310L)),
+          newStreamRecord("test", 2, 0L, Timestamp(300L))
+        )
+        records.foreach(r => rewindingSinker.write(r))
+
+        baseSinker.writtenRecords.map(_.tpo) should contain theSameElementsInOrderAs records.map(_.tpo)
+      }
+    }
+
+    it("should only pass through new messages for any rewind range") {
+
+      val rewindRanges = for {
+        range <- Gen.choose(0L, 1000L)
+        rangeType <- Gen.oneOf(
+          (r: Long) => OffsetRange(r),
+          (r: Long) => WatermarkRange(Duration.ofMillis(r))
+        )
+      } yield rangeType(range)
+
+      forAll(rewindRanges) { rewindRange =>
+        {
+          val rewindingSinker = new TestRewindingSinker(baseSinker, rewindRange)
+          rewindingSinker.initialize(kafka)
+
+          val records = Seq(
+            newStreamRecord("test", 0, 31L, Timestamp(220L)),
+            newStreamRecord("test", 0, 32L, Timestamp(219L)),
+            newStreamRecord("test", 1, 21L, Timestamp(299L)),
+            newStreamRecord("test", 1, 22L, Timestamp(310L)),
+            newStreamRecord("test", 2, 0L, Timestamp(300L))
+          )
+          records.foreach(r => rewindingSinker.write(r))
+
+          baseSinker.writtenRecords.map(_.tpo) should contain theSameElementsInOrderAs records.map(_.tpo)
+        }
+      }
+    }
+  }
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/source/MaxWatermarkProviderTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/source/MaxWatermarkProviderTest.scala
@@ -9,7 +9,7 @@
 package com.adform.streamloader.source
 
 import com.adform.streamloader.model.Timestamp
-import com.adform.streamloader.util.TimeProvider
+import com.adform.streamloader.util.{MockTimeProvider, TimeProvider}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -17,10 +17,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import java.time.Duration
 
 class MaxWatermarkProviderTest extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
-
-  class MockTimeProvider(var time: Long) extends TimeProvider {
-    override def currentMillis: Long = time
-  }
 
   it("should advance the watermark when time advances") {
     val wp = new MaxWatermarkProvider(Duration.ofHours(1))(new MockTimeProvider(0L))

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/source/MockKafkaContext.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/source/MockKafkaContext.scala
@@ -8,13 +8,15 @@
 
 package com.adform.streamloader.source
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import com.adform.streamloader.model.{StreamPosition, StreamRecord, Timestamp}
+import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetAndTimestamp}
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.mutable
 
 class MockKafkaContext extends KafkaContext {
-  val commits = mutable.Map.empty[TopicPartition, Seq[OffsetAndMetadata]]
+  private val commits = mutable.Map.empty[TopicPartition, Seq[OffsetAndMetadata]]
+  private val writes = mutable.Map.empty[TopicPartition, Seq[OffsetAndTimestamp]]
 
   private var commitsInvoked = 0
   private var failOnCommit = -1
@@ -24,6 +26,31 @@ class MockKafkaContext extends KafkaContext {
     failOnCommit = seqNo
   }
 
+  def write(topicPartition: TopicPartition, offsetAndTimestamp: OffsetAndTimestamp): Unit = {
+    writes.updateWith(topicPartition)(offsets => Some(offsets.getOrElse(Seq.empty) :+ offsetAndTimestamp))
+  }
+
+  def write(topic: String, partition: Short, offset: Long, timestamp: Long): Unit = {
+    write(new TopicPartition(topic, partition), new OffsetAndTimestamp(offset, timestamp))
+  }
+
+  def write(record: StreamRecord): Unit = {
+    write(
+      record.topicPartition,
+      new OffsetAndTimestamp(record.consumerRecord.offset(), record.consumerRecord.timestamp())
+    )
+  }
+
+  def commitWrites(): Map[TopicPartition, Option[StreamPosition]] = {
+    val positionsToCommit = writes.map { case (tp, tpWrites) =>
+      val offset = tpWrites.last.offset() + 1
+      val watermark = tpWrites.map(_.timestamp()).max
+      tp -> Some(StreamPosition(offset, Timestamp(watermark)))
+    }.toMap
+    commitSync(positionsToCommit.map(kv => (kv._1, new OffsetAndMetadata(kv._2.get.offset))))
+    positionsToCommit
+  }
+
   override val consumerGroup: String = "mock-consumer-group"
 
   override def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): Unit = {
@@ -31,7 +58,16 @@ class MockKafkaContext extends KafkaContext {
     if (failOnCommit == commitsInvoked) {
       throw new UnsupportedOperationException("Offset commit failed")
     }
-    offsets.foreach(o => commits.updateWith(o._1)(offs => Some(offs.getOrElse(Seq.empty) :+ o._2)))
+    offsets.foreach { case (tp, om) =>
+      commits.updateWith(tp)(offs => Some(offs.getOrElse(Seq.empty) :+ om))
+    }
+  }
+
+  override def offsetsForTimes(ts: Map[TopicPartition, Long]): Map[TopicPartition, Option[OffsetAndTimestamp]] = {
+    ts.map { case (topicPartition, timestampToFind) =>
+      val watermark = writes.get(topicPartition).flatMap(_.find(o => o.timestamp() >= timestampToFind))
+      topicPartition -> watermark
+    }
   }
 
   override def committed(topicPartitions: Set[TopicPartition]): Map[TopicPartition, Option[OffsetAndMetadata]] =

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/util/MockTimeProvider.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/util/MockTimeProvider.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.util
+
+class MockTimeProvider(var time: Long) extends TimeProvider {
+  override def currentMillis: Long = time
+}

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/util/TestExtensions.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/util/TestExtensions.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.util
+
+import com.adform.streamloader.model.StreamRecord
+
+object TestExtensions {
+
+  implicit class RichStreamRecord(val record: StreamRecord) extends AnyVal {
+
+    /**
+      * Gets the topic-partition to offset mapping for a given record.
+      */
+    def tpo: (String, Long) = record.topicPartition.toString -> record.consumerRecord.offset()
+  }
+}


### PR DESCRIPTION
Add an implementation for a `RewindingPartitionGroupSinker` that wraps another `Sinker` and rewinds the streams backwards during initialization. For the whole "rewind period" records are only being "touched" and afterwards they get forwarded to the base sinker. This can be used for implementing stateful sinks that need to do some kind of a "warm-up" before writing, e.g. building up a de-duplication cache.