### PR TITLE
Small improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,28 +10,28 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache Coursier
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/coursier
         key: ${{ runner.os }}-coursier-${{ hashFiles('**/*.sbt') }}
 
     - name: Cache SBT
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
 
     - name: Setup JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '11'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,38 +8,39 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache Coursier
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/coursier
         key: ${{ runner.os }}-coursier-${{ hashFiles('**/*.sbt') }}
 
     - name: Cache SBT
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
 
-    - name: Setup JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Setup JDK
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: '11'
 
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1
 
     - name: Import Sonatype GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@v1
+      uses: crazy-max/ghaction-import-gpg@v5
       env:
-        GPG_PRIVATE_KEY: ${{ secrets.PGP_SECRET }}
-        PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        gpg_private_key: ${{ secrets.PGP_SECRET }}
+        passphrase: ${{ secrets.PGP_PASSPHRASE }}
 
     - name: Setup Git Token
       uses: fregante/setup-git-user@v1

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "stream-loader"
 ThisBuild / organization := "com.adform"
 ThisBuild / organizationName := "Adform"
 ThisBuild / scalaVersion := "2.13.10"
-ThisBuild / scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-release", "8")
+ThisBuild / scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-release", "11")
 
 ThisBuild / startYear := Some(2020)
 ThisBuild / licenses += ("MPL-2.0", new URL("http://mozilla.org/MPL/2.0/"))
@@ -15,14 +15,12 @@ ThisBuild / developers := List(
 enablePlugins(GitVersioning)
 ThisBuild / git.useGitDescribe := true
 
-ThisBuild / useCoursier := false
-
 val gitRepo = "git@github.com:adform/stream-loader.git"
 val gitRepoUrl = "https://github.com/adform/stream-loader"
 
-val scalaTestVersion = "3.2.14"
+val scalaTestVersion = "3.2.15"
 val scalaCheckVersion = "1.17.0"
-val scalaCheckTestVersion = "3.2.14.0"
+val scalaCheckTestVersion = "3.2.15.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -41,7 +39,7 @@ lazy val `stream-loader-core` = project
       "com.github.luben"   % "zstd-jni"          % "1.5.2-5",
       "com.univocity"      % "univocity-parsers" % "2.9.1",
       "org.json4s"        %% "json4s-native"     % "4.0.6",
-      "io.micrometer"      % "micrometer-core"   % "1.10.2",
+      "io.micrometer"      % "micrometer-core"   % "1.10.3",
       "org.scalatest"     %% "scalatest"         % scalaTestVersion      % "test",
       "org.scalatestplus" %% "scalacheck-1-17"   % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"        % scalaCheckVersion     % "test",
@@ -61,10 +59,10 @@ lazy val `stream-loader-clickhouse` = project
   .settings(
     resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "ru.yandex.clickhouse" % "clickhouse-jdbc" % "0.3.1",
-      "org.scalatest"       %% "scalatest"       % scalaTestVersion      % "test",
-      "org.scalatestplus"   %% "scalacheck-1-17" % scalaCheckTestVersion % "test",
-      "org.scalacheck"      %% "scalacheck"      % scalaCheckVersion     % "test"
+      "com.clickhouse"     % "clickhouse-jdbc" % "0.3.2-patch11",
+      "org.scalatest"     %% "scalatest"       % scalaTestVersion      % "test",
+      "org.scalatestplus" %% "scalacheck-1-17" % scalaCheckTestVersion % "test",
+      "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion     % "test"
     )
   )
 
@@ -90,15 +88,14 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.17.192",
+      "software.amazon.awssdk" % "s3"              % "2.19.15",
       "org.scalatest"         %% "scalatest"       % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.357"       % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.383"       % "test",
       "org.gaul"               % "s3proxy"         % "2.0.0"          % "test"
     )
   )
 
-val verticaVersion = "9.2.1-0"
-val verticaJarUrl = s"https://www.vertica.com/client_drivers/9.2.x/$verticaVersion/vertica-jdbc-$verticaVersion.jar"
+val verticaVersion = "12.0.3-0"
 
 lazy val `stream-loader-vertica` = project
   .in(file("stream-loader-vertica"))
@@ -106,10 +103,10 @@ lazy val `stream-loader-vertica` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      (("com.vertica"      % "vertica-jdbc"    % verticaVersion) from verticaJarUrl) % "provided",
-      "org.scalatest"     %% "scalatest"       % scalaTestVersion                    % "test",
-      "org.scalatestplus" %% "scalacheck-1-17" % scalaCheckTestVersion               % "test",
-      "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion                   % "test"
+      "com.vertica.jdbc"   % "vertica-jdbc"    % verticaVersion        % "provided",
+      "org.scalatest"     %% "scalatest"       % scalaTestVersion      % "test",
+      "org.scalatestplus" %% "scalacheck-1-17" % scalaCheckTestVersion % "test",
+      "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion     % "test"
     )
   )
 
@@ -132,14 +129,15 @@ lazy val `stream-loader-tests` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe"       % "config"          % "1.4.2",
-      "ch.qos.logback"     % "logback-classic" % "1.4.5",
-      "com.zaxxer"         % "HikariCP"        % "5.0.1",
-      "com.vertica"        % "vertica-jdbc"    % verticaVersion from verticaJarUrl,
-      "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion,
-      "org.scalatest"     %% "scalatest"       % scalaTestVersion              % "test,it",
-      "org.scalatestplus" %% "scalacheck-1-17" % scalaCheckTestVersion         % "test,it",
-      ("com.spotify"       % "docker-client"   % "8.16.0" classifier "shaded") % "it"
+      "com.typesafe"       % "config"           % "1.4.2",
+      "ch.qos.logback"     % "logback-classic"  % "1.4.5",
+      "com.zaxxer"         % "HikariCP"         % "5.0.1",
+      "com.vertica.jdbc"   % "vertica-jdbc"     % verticaVersion,
+      "org.scalacheck"    %% "scalacheck"       % scalaCheckVersion,
+      "org.scalatest"     %% "scalatest"        % scalaTestVersion              % "test,it",
+      "org.scalatestplus" %% "scalacheck-1-17"  % scalaCheckTestVersion         % "test,it",
+      ("com.spotify"       % "docker-client"    % "8.16.0" classifier "shaded") % "it",
+      "org.slf4j"          % "log4j-over-slf4j" % "2.0.6"                       % "it"
     ),
     test := {}, // only integration tests present
     publish := {},

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2022.13"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2023.0"
 
 addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.7.0")
 

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
@@ -9,7 +9,7 @@
 package com.adform.streamloader.clickhouse
 
 import com.adform.streamloader.sink.file.{FileBuilder, FileBuilderFactory}
-import com.clickhouse.client.ClickHouseFormat
+import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * A FileBuilder able to build files that can be loaded to ClickHouse.
@@ -22,6 +22,11 @@ trait ClickHouseFileBuilder[-R] extends FileBuilder[R] {
     * The ClickHouse file format for the files being built.
     */
   def format: ClickHouseFormat
+
+  /**
+    * Compression to use for the files being constructed.
+    */
+  def compression: ClickHouseCompression
 }
 
 trait ClickHouseFileBuilderFactory[R] extends FileBuilderFactory[R, ClickHouseFileBuilder[R]] {

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
@@ -9,7 +9,7 @@
 package com.adform.streamloader.clickhouse
 
 import com.adform.streamloader.sink.file.{FileBuilder, FileBuilderFactory}
-import ru.yandex.clickhouse.domain.ClickHouseFormat
+import com.clickhouse.client.ClickHouseFormat
 
 /**
   * A FileBuilder able to build files that can be loaded to ClickHouse.

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
@@ -11,7 +11,7 @@ package com.adform.streamloader.clickhouse
 import java.io.File
 import com.adform.streamloader.model.StreamRange
 import com.adform.streamloader.sink.file.FileRecordBatch
-import com.clickhouse.client.ClickHouseFormat
+import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * A file containing a batch of records in some ClickHouse supported format that can be loaded to ClickHouse.
@@ -19,6 +19,7 @@ import com.clickhouse.client.ClickHouseFormat
 case class ClickHouseFileRecordBatch(
     file: File,
     format: ClickHouseFormat,
+    compression: ClickHouseCompression,
     recordRanges: Seq[StreamRange],
     rowCount: Long
 ) extends FileRecordBatch

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
@@ -11,7 +11,7 @@ package com.adform.streamloader.clickhouse
 import java.io.File
 import com.adform.streamloader.model.StreamRange
 import com.adform.streamloader.sink.file.FileRecordBatch
-import ru.yandex.clickhouse.domain.ClickHouseFormat
+import com.clickhouse.client.ClickHouseFormat
 
 /**
   * A file containing a batch of records in some ClickHouse supported format that can be loaded to ClickHouse.

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
@@ -29,7 +29,15 @@ class ClickHouseFileRecordBatcher[R](
   ): Option[ClickHouseFileRecordBatch] = {
     fileBuilder
       .build()
-      .map(f => ClickHouseFileRecordBatch(f, fileBuilder.format, recordRanges, fileBuilder.getRecordCount))
+      .map(f =>
+        ClickHouseFileRecordBatch(
+          f,
+          fileBuilder.format,
+          fileBuilder.compression,
+          recordRanges,
+          fileBuilder.getRecordCount
+        )
+      )
   }
 }
 

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileStorage.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileStorage.scala
@@ -8,19 +8,17 @@
 
 package com.adform.streamloader.clickhouse
 
-import java.sql.Connection
 import com.adform.streamloader.model._
 import com.adform.streamloader.sink.batch.storage.InDataOffsetBatchStorage
 import com.adform.streamloader.util.Logging
-import com.clickhouse.client.{ClickHouseCompression, ClickHouseFile, ClickHouseFormat, ClickHouseValue}
+import com.clickhouse.client.ClickHouseFile
 import com.clickhouse.jdbc.ClickHouseConnection
-
-import javax.sql.DataSource
 import org.apache.kafka.common.TopicPartition
 
-import scala.jdk.CollectionConverters._
-
+import java.sql.Connection
+import javax.sql.DataSource
 import scala.collection.concurrent.TrieMap
+import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 /**
@@ -83,7 +81,7 @@ class ClickHouseFileStorage(
       Using.resource(connection.unwrap(classOf[ClickHouseConnection]).createStatement) { statement =>
         statement
           .write()
-          .data(ClickHouseFile.of(batch.file, ClickHouseCompression.NONE, 0, batch.format))
+          .data(ClickHouseFile.of(batch.file, batch.compression, 1, batch.format))
           .table(table)
           .params(Map("max_insert_block_size" -> batch.rowCount.toString).asJava) // atomic insert
           .executeAndWait()

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
@@ -10,7 +10,7 @@ package com.adform.streamloader.clickhouse.rowbinary
 
 import com.adform.streamloader.clickhouse.ClickHouseFileBuilder
 import com.adform.streamloader.sink.file.{Compression, StreamFileBuilder}
-import ru.yandex.clickhouse.domain.ClickHouseFormat
+import com.clickhouse.client.ClickHouseFormat
 
 /**
   * File builder for the ClickHouse native RowBinary file format, requires

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
@@ -10,7 +10,7 @@ package com.adform.streamloader.clickhouse.rowbinary
 
 import com.adform.streamloader.clickhouse.ClickHouseFileBuilder
 import com.adform.streamloader.sink.file.{Compression, StreamFileBuilder}
-import com.clickhouse.client.ClickHouseFormat
+import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * File builder for the ClickHouse native RowBinary file format, requires
@@ -21,13 +21,23 @@ import com.clickhouse.client.ClickHouseFormat
   * @tparam R type of the records written to files being built.
   */
 class RowBinaryClickHouseFileBuilder[-R: RowBinaryClickHouseRecordEncoder](
+    fileCompression: Compression = Compression.NONE,
     bufferSizeBytes: Int = 8192
 ) extends StreamFileBuilder[R](
       os => new RowBinaryClickHouseRecordStreamWriter[R](os),
-      Compression.NONE,
+      fileCompression,
       bufferSizeBytes
     )
     with ClickHouseFileBuilder[R] {
 
   override val format: ClickHouseFormat = ClickHouseFormat.RowBinary
+
+  override def compression: ClickHouseCompression = fileCompression match {
+    case Compression.NONE => ClickHouseCompression.NONE
+    case Compression.ZSTD => ClickHouseCompression.ZSTD
+    case Compression.GZIP => ClickHouseCompression.GZIP
+    case Compression.BZIP => ClickHouseCompression.BZ2
+    case Compression.LZ4 => ClickHouseCompression.LZ4
+    case _ => throw new UnsupportedOperationException(s"Compression $fileCompression is not supported by ClickHouse")
+  }
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupingSink.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/PartitionGroupingSink.scala
@@ -13,7 +13,7 @@ import com.adform.streamloader.source.KafkaContext
 import com.adform.streamloader.util.Logging
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 
 /**
   * An abstract sink that implements partition assignment/revocation by grouping partitions to sets
@@ -27,8 +27,8 @@ import scala.collection.concurrent.TrieMap
   */
 trait PartitionGroupingSink extends Sink with Logging {
 
-  private val partitionGroups = TrieMap[String, (Set[TopicPartition], PartitionGroupSinker)]()
-  private val partitionSinkers = TrieMap[TopicPartition, PartitionGroupSinker]()
+  private val partitionGroups = mutable.HashMap.empty[String, (Set[TopicPartition], PartitionGroupSinker)]
+  private val partitionSinkers = mutable.HashMap.empty[TopicPartition, PartitionGroupSinker]
 
   protected var kafkaContext: KafkaContext = _
 

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
@@ -11,7 +11,7 @@ package com.adform.streamloader.sink.batch
 import com.adform.streamloader.model.{StreamPosition, StreamRange, StreamRangeBuilder, StreamRecord}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 
 /**
   * A base trait representing a batch of records.
@@ -38,7 +38,7 @@ trait RecordBatch {
   * @tparam B Type of the batches being built.
   */
 abstract class RecordBatchBuilder[+B <: RecordBatch] {
-  private val recordRangeBuilders: TrieMap[TopicPartition, StreamRangeBuilder] = TrieMap.empty
+  private val recordRangeBuilders: mutable.HashMap[TopicPartition, StreamRangeBuilder] = mutable.HashMap.empty
   private var recordCount = 0L
 
   def currentRecordRanges: Seq[StreamRange] = recordRangeBuilders.values.map(_.build()).toSeq

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatchingSinker.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatchingSinker.scala
@@ -160,7 +160,7 @@ class RecordBatchingSinker[B <: RecordBatch](
     })
   }
 
-  object Metrics {
+  private object Metrics {
 
     private val commonTags = Seq(
       MetricTag("partition-group", groupName),

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitioningFileRecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitioningFileRecordBatcher.scala
@@ -14,7 +14,7 @@ import com.adform.streamloader.model.StreamRecord
 import com.adform.streamloader.sink.batch.{RecordBatchBuilder, RecordBatcher, RecordFormatter, RecordPartitioner}
 import com.adform.streamloader.util.TimeProvider
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 
 /**
   * A record batcher that distributes records into user defined partitions using a given partitioner
@@ -53,7 +53,7 @@ class PartitioningFileRecordBatcher[P, R](
   override def newBatchBuilder(): RecordBatchBuilder[PartitionedFileRecordBatch[P, SingleFileRecordBatch]] =
     new RecordBatchBuilder[PartitionedFileRecordBatch[P, SingleFileRecordBatch]] {
 
-      private val partitionBuilders: TrieMap[P, FileRecordBatchBuilder] = TrieMap.empty
+      private val partitionBuilders: mutable.HashMap[P, FileRecordBatchBuilder] = mutable.HashMap.empty
 
       override def add(record: StreamRecord): Unit = {
         super.add(record)

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
@@ -19,7 +19,7 @@ import java.util
 import java.util.Properties
 import java.util.concurrent.locks.ReentrantLock
 import java.util.regex.Pattern
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 /**
@@ -51,8 +51,8 @@ class KafkaSource(
   private var consumerLock: ReentrantLock = _
   private var consumer: KafkaConsumer[Array[Byte], Array[Byte]] = _
 
-  private val watermarkProviders: TrieMap[TopicPartition, WatermarkProvider] = TrieMap.empty
-  private val watermarkMetricGauges: TrieMap[TopicPartition, Gauge] = TrieMap.empty
+  private val watermarkProviders: mutable.HashMap[TopicPartition, WatermarkProvider] = mutable.HashMap.empty
+  private val watermarkMetricGauges: mutable.HashMap[TopicPartition, Gauge] = mutable.HashMap.empty
 
   private def withLock[T](code: => T): T = {
     consumerLock.lockInterruptibly()

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/ClickHouseTests.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/ClickHouseTests.scala
@@ -43,6 +43,7 @@ class ClickHouseTests
   override def beforeAll(): Unit = {
     super.beforeAll()
     hikariConf = new HikariConfig()
+    hikariConf.setDriverClassName(classOf[com.clickhouse.jdbc.ClickHouseDriver].getName)
     hikariConf.setJdbcUrl(s"jdbc:clickhouse://${clickHouseContainer.endpoint}/${clickHouseConfig.dbName}")
     hikariConf.addDataSourceProperty("host", clickHouseContainer.ip)
     hikariConf.addDataSourceProperty("port", jdbcPort)

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.4.5.9")
+case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.12.2.25")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {
@@ -45,7 +45,6 @@ trait ClickHouse { this: Docker =>
   def clickHouseContainer: ContainerWithEndpoint = clickHouse
 
   def clickHouseInit(): Unit = {
-    Class.forName(classOf[ru.yandex.clickhouse.ClickHouseDriver].getName)
     clickHouse = startClickHouseContainer()
   }
 

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2022-05-08T23-50-31Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2023-01-06T18-11-18Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Vertica.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Vertica.scala
@@ -20,10 +20,10 @@ import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 case class VerticaConfig(
-    dbName: String = "docker",
+    dbName: String = "",
     user: String = "dbadmin",
     password: String = "",
-    image: String = "jbfavre/vertica:9.2.0-7_centos-7"
+    image: String = "vertica/vertica-ce:12.0.2-0"
 )
 
 trait VerticaTestFixture extends Vertica with BeforeAndAfterAll { this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/ClickHouseStorageBackend.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/ClickHouseStorageBackend.scala
@@ -8,24 +8,22 @@
 
 package com.adform.streamloader.storage
 
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
-import java.util.UUID
-
 import com.adform.streamloader.clickhouse.ClickHouseFileStorage
 import com.adform.streamloader.fixtures.{Container, ContainerWithEndpoint, DockerNetwork, SimpleContainer}
 import com.adform.streamloader.model.{ExampleMessage, StreamPosition, Timestamp}
 import com.adform.streamloader.source.KafkaContext
 import com.adform.streamloader.util.Retry
 import com.adform.streamloader.{BuildInfo, Loader}
+import com.clickhouse.jdbc.ClickHouseArray
 import com.spotify.docker.client.DockerClient
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
 import com.zaxxer.hikari.HikariConfig
-import javax.sql.DataSource
 import org.apache.kafka.common.TopicPartition
 import org.scalacheck.Arbitrary
-import ru.yandex.clickhouse.ClickHouseArray
 
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import javax.sql.DataSource
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
@@ -120,7 +118,6 @@ case class ClickHouseStorageBackend(
 
     val containerCreation = docker.createContainer(config, loaderName)
     SimpleContainer(containerCreation.id, loaderName)
-
   }
 
   override def getContent: StorageContent[ExampleMessage] =
@@ -144,7 +141,7 @@ case class ClickHouseStorageBackend(
                 ExampleMessage(
                   rs.getInt("id"),
                   rs.getString("name"),
-                  rs.getTimestamp("timestamp").toInstant.atZone(ZoneId.of("UTC")).toLocalDateTime,
+                  rs.getTimestamp("timestamp").toLocalDateTime,
                   rs.getDouble("height"),
                   rs.getFloat("width"),
                   rs.getBoolean("is_enabled"),

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/ClickHouseStorageBackend.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/ClickHouseStorageBackend.scala
@@ -24,7 +24,7 @@ import org.scalacheck.Arbitrary
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import javax.sql.DataSource
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.util.Using
@@ -127,7 +127,7 @@ case class ClickHouseStorageBackend(
           ps.setQueryTimeout(5)
           Using.resource(ps.executeQuery()) { rs =>
             val content: ListBuffer[ExampleMessage] = collection.mutable.ListBuffer[ExampleMessage]()
-            val positions: TrieMap[TopicPartition, ListBuffer[StreamPosition]] = TrieMap.empty
+            val positions: mutable.HashMap[TopicPartition, ListBuffer[StreamPosition]] = mutable.HashMap.empty
             while (rs.next()) {
 
               val topicPartition = new TopicPartition(rs.getString(TOPIC_COLUMN), rs.getInt(PARTITION_COLUMN))

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/VerticaStorageBackend.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/storage/VerticaStorageBackend.scala
@@ -20,11 +20,12 @@ import com.adform.streamloader.{BuildInfo, Loader}
 import com.spotify.docker.client.DockerClient
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig}
 import com.zaxxer.hikari.HikariConfig
+
 import javax.sql.DataSource
 import org.apache.kafka.common.TopicPartition
 import org.scalacheck.Arbitrary
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.util.Using
@@ -127,7 +128,7 @@ abstract class VerticaStorageBackend(
           ps.setQueryTimeout(5)
           Using.resource(ps.executeQuery()) { rs =>
             val content: ListBuffer[ExampleMessage] = collection.mutable.ListBuffer[ExampleMessage]()
-            val positions: TrieMap[TopicPartition, ListBuffer[StreamPosition]] = TrieMap.empty
+            val positions: mutable.HashMap[TopicPartition, ListBuffer[StreamPosition]] = mutable.HashMap.empty
             while (rs.next()) {
 
               content.addOne(

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/ClickHouse.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/ClickHouse.scala
@@ -16,6 +16,7 @@ import com.adform.streamloader.sink.encoding.macros.DataTypeEncodingAnnotation.D
 import com.adform.streamloader.sink.file.FileCommitStrategy.ReachedAnyOf
 import com.adform.streamloader.model.{ExampleMessage, Timestamp}
 import com.adform.streamloader.sink.batch.{RecordBatchingSink, RecordFormatter}
+import com.adform.streamloader.sink.file.Compression
 import com.adform.streamloader.source.KafkaSource
 import com.adform.streamloader.util.ConfigExtensions._
 import com.adform.streamloader.{Loader, StreamLoader}
@@ -117,7 +118,7 @@ object TestClickHouseLoader extends Loader {
         ClickHouseFileRecordBatcher
           .builder()
           .recordFormatter(recordFormatter)
-          .fileBuilderFactory(() => new RowBinaryClickHouseFileBuilder())
+          .fileBuilderFactory(() => new RowBinaryClickHouseFileBuilder(Compression.ZSTD))
           .fileCommitStrategy(ReachedAnyOf(recordsWritten = Some(cfg.getLong("file.max.records"))))
           .build()
       )

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/ClickHouse.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/ClickHouse.scala
@@ -71,6 +71,7 @@ object TestClickHouseLoader extends Loader {
     val port = cfg.getInt("clickhouse.port")
     val db = cfg.getString("clickhouse.db")
 
+    hikariConf.setDriverClassName(classOf[com.clickhouse.jdbc.ClickHouseDriver].getName)
     hikariConf.setJdbcUrl(s"jdbc:clickhouse://$host:$port/$db")
 
     hikariConf.addDataSourceProperty("host", host)


### PR DESCRIPTION
Collection of small-to-medium changes:

 - Bumped build to JDK 11
 - Bump all GitHub action plugins
 - Upgraded `sbt`, fixed all warnings in build
 - Switched to coursier
 - Upgraded `s3` sdk
 - Switched to official Vertica docker image / jdbc driver, bumped them
 - Switched to `bitnami/kafka` docker image, removed zookeeper, moved to KRaft mode
 - Upgraded `clickhouse-jdbc` and switched to `com.clickhouse` package
 - Added support for compression in ClickHouse
 - Switched from `TrieMap` to `mutable.HashMap` in all single-threaded code
 - Reverted to the `watermark.delay.ms` metric instead of `watermark.ms`
 - Made internal `Metrics` objects private