### PR TITLE
Compress Kafka offset metadata

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/model/StreamRange.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/model/StreamRange.scala
@@ -8,11 +8,15 @@
 
 package com.adform.streamloader.model
 
+import org.apache.kafka.common.TopicPartition
+
 /**
   * Specification of a range of records consumed from a single topic partition,
   * the start and end positions are both inclusive.
   */
-case class StreamRange(topic: String, partition: Int, start: StreamPosition, end: StreamPosition)
+case class StreamRange(topic: String, partition: Int, start: StreamPosition, end: StreamPosition) {
+  def topicPartition: TopicPartition = new TopicPartition(topic, partition)
+}
 
 /**
   * A mutable builder of [[StreamRange]].

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/storage/MockTwoPhaseCommitFileStorage.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/storage/MockTwoPhaseCommitFileStorage.scala
@@ -8,7 +8,6 @@
 
 package com.adform.streamloader.sink.batch.storage
 
-import com.adform.streamloader.sink.batch.storage.TwoPhaseCommitBatchStorage
 import com.adform.streamloader.sink.file.SingleFileRecordBatch
 
 import scala.collection.mutable

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitFileStorageTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitFileStorageTest.scala
@@ -68,7 +68,7 @@ class TwoPhaseCommitFileStorageTest extends AnyFunSpec with Matchers {
           Some(
             new OffsetAndMetadata(
               range.end.offset + 1,
-              TwoPhaseCommitMetadata[FileStaging](range.end.watermark, None).toJson
+              TwoPhaseCommitMetadata[FileStaging](range.end.watermark, None).serialize
             )
           )
         )

--- a/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/HadoopFileStorageTest.scala
+++ b/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/HadoopFileStorageTest.scala
@@ -8,7 +8,8 @@
 
 package com.adform.streamloader.hadoop
 
-import com.adform.streamloader.model.{StreamRange, StreamPosition, Timestamp}
+import com.adform.streamloader.model.{StreamPosition, StreamRange, Timestamp}
+import com.adform.streamloader.sink.batch.storage.TwoPhaseCommitMetadata
 import com.adform.streamloader.sink.file.{FilePathFormatter, PartitionedFileRecordBatch, SingleFileRecordBatch}
 import com.adform.streamloader.source.MockKafkaContext
 import org.apache.hadoop.conf.Configuration
@@ -63,7 +64,9 @@ class HadoopFileStorageTest extends AnyFunSpec with Matchers {
       storage.commitBatch(batch)
 
       destFile.exists() shouldBe true
-      context.committed(Set(tp)) shouldEqual Map(tp -> Some(new OffsetAndMetadata(11, "{\"watermark\":100}")))
+      context.committed(Set(tp)) shouldEqual Map(
+        tp -> Some(new OffsetAndMetadata(11, TwoPhaseCommitMetadata[MultiFileStaging](Timestamp(100), None).serialize))
+      )
     } finally {
       fs.close()
       sourceFile.delete()

--- a/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3FileStorageTest.scala
+++ b/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3FileStorageTest.scala
@@ -10,7 +10,8 @@ package com.adform.streamloader.s3
 
 import java.io.File
 import java.util.UUID
-import com.adform.streamloader.model.{StreamRange, StreamPosition, Timestamp}
+import com.adform.streamloader.model.{StreamPosition, StreamRange, Timestamp}
+import com.adform.streamloader.sink.batch.storage.TwoPhaseCommitMetadata
 import com.adform.streamloader.sink.file.{FilePathFormatter, PartitionedFileRecordBatch, SingleFileRecordBatch}
 import com.adform.streamloader.source.MockKafkaContext
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -61,7 +62,11 @@ class S3FileStorageTest extends AnyFunSpec with Matchers with MockS3 {
         .toArray
 
       stored should contain theSameElementsAs Array("filename")
-      context.committed(Set(tp)) shouldEqual Map(tp -> Some(new OffsetAndMetadata(11, "{\"watermark\":100}")))
+      context.committed(Set(tp)) shouldEqual Map(
+        tp -> Some(
+          new OffsetAndMetadata(11, TwoPhaseCommitMetadata[S3MultiFileStaging](Timestamp(100), None).serialize)
+        )
+      )
 
     } finally {
       sourceFile.delete()


### PR DESCRIPTION
The `TwoPhaseCommitBatchStorage` stores a JSON value in the Kafka offset [metadata](https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/OffsetAndMetadata.html#metadata()) field during the staging step that can become relatively large in some scenarios. E.g. the HDFS loader with partitioning can try to stage something like the following:
```scala
    val stagePath = "/user/hive/warehouse/database.db/table"
    val destPath = "/user/hive/warehouse/database.db/table"

    val s = MultiFileStaging(
      Seq(
        FileStaging(
          s"$stagePath/6c7ea313-1ab8-443c-b96a-c5a8bd47f310.parquet",
          s"$destPath/dt=20221201/6c7ea313-1ab8-443c-b96a-c5a8bd47f310.parquet"
        ),
        FileStaging(
          s"$stagePath/1971784a-3416-4d51-8b52-72bf191e5bc6.parquet",
          s"$destPath/dt=20221202/1971784a-3416-4d51-8b52-72bf191e5bc6.parquet"
        ),
        FileStaging(
          s"$stagePath/7e341714-93ed-4aab-8879-67f39b2c3d69.parquet",
          s"$destPath/dt=20221203/7e341714-93ed-4aab-8879-67f39b2c3d69.parquet"
        ),
        FileStaging(
          s"$stagePath/e8ba208a-bdc5-4032-9891-158bcad42d65.parquet",
          s"$destPath/dt=20221204/e8ba208a-bdc5-4032-9891-158bcad42d65.parquet"
        ),
        FileStaging(
          s"$stagePath/a10d1f05-2306-43b8-94d7-ead2eb45a4e9.parquet",
          s"$destPath/dt=20221205/a10d1f05-2306-43b8-94d7-ead2eb45a4e9.parquet"
        )
      )
    )

    val metadata = TwoPhaseCommitMetadata(
      Timestamp(1673600890000L),
      Some(
        StagedOffsetCommit(
          s,
          StreamPosition(1234567L, Timestamp(1673601234000L)),
          StreamPosition(1235567L, Timestamp(1673602345000L))
        )
      )
    )
```
This gets serialized to 1301 bytes. Kafka brokers reject any commits with metadata size above `offset.metadata.max.bytes` (4kb by default) with `org.apache.kafka.common.errors.OffsetMetadataTooLarge: The metadata field of the offset request was too large`.

This PR additionally ZSTD compresses and Base64 encodes the serialized JSON value so that in the example above it gets reduced to 452 bytes, i.e. a third of the original size. 

For simpler staging metadata, e.g. in the case of S3 like the following:
```scala
    val s = S3MultiFileStaging(
      Seq(
        S3FileStaging("test1234", "1111222333", "/dt=20220101")
      )
    )
```
the serialized size changes from 219 bytes to 200 bytes.

In order to maintain backwards compatibility the deserializer assumes metadata is uncompressed if base64 decoding fails, but the serializer will compress/encode on the next stage phase, thus permanently switching to the new format.

We also add a new metric `kafka.commit.staged.metadata.size.bytes` for monitoring the size of the staging metadata.