### PR TITLE
Reduce Kafka offset commit metadata metric size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"     % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"   % "kafka-clients"     % "3.3.1",
+      "org.apache.kafka"   % "kafka-clients"     % "3.3.2",
       "org.log4s"         %% "log4s"             % "1.10.0",
       "org.anarres.lzo"    % "lzo-commons"       % "1.0.6",
       "org.xerial.snappy"  % "snappy-java"       % "1.1.8.4",
@@ -66,7 +66,7 @@ lazy val `stream-loader-clickhouse` = project
   .settings(
     resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "com.clickhouse"     % "clickhouse-jdbc" % "0.3.2-patch11",
+      "com.clickhouse"     % "clickhouse-jdbc" % "0.4.0",
       "org.scalatest"     %% "scalatest"       % scalaTestVersion      % "test",
       "org.scalatestplus" %% "scalacheck-1-17" % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"      % scalaCheckVersion     % "test"
@@ -95,9 +95,9 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.19.15",
+      "software.amazon.awssdk" % "s3"              % "2.19.23",
       "org.scalatest"         %% "scalatest"       % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.383"       % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.392"       % "test",
       "org.gaul"               % "s3proxy"         % "2.0.0"          % "test"
     )
   )

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
@@ -9,7 +9,7 @@
 package com.adform.streamloader.clickhouse
 
 import com.adform.streamloader.sink.file.{FileBuilder, FileBuilderFactory}
-import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
+import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * A FileBuilder able to build files that can be loaded to ClickHouse.

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
@@ -11,7 +11,7 @@ package com.adform.streamloader.clickhouse
 import java.io.File
 import com.adform.streamloader.model.StreamRange
 import com.adform.streamloader.sink.file.FileRecordBatch
-import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
+import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * A file containing a batch of records in some ClickHouse supported format that can be loaded to ClickHouse.

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileStorage.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileStorage.scala
@@ -11,7 +11,7 @@ package com.adform.streamloader.clickhouse
 import com.adform.streamloader.model._
 import com.adform.streamloader.sink.batch.storage.InDataOffsetBatchStorage
 import com.adform.streamloader.util.Logging
-import com.clickhouse.client.ClickHouseFile
+import com.clickhouse.data.ClickHouseFile
 import com.clickhouse.jdbc.ClickHouseConnection
 import org.apache.kafka.common.TopicPartition
 

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
@@ -10,7 +10,7 @@ package com.adform.streamloader.clickhouse.rowbinary
 
 import com.adform.streamloader.clickhouse.ClickHouseFileBuilder
 import com.adform.streamloader.sink.file.{Compression, StreamFileBuilder}
-import com.clickhouse.client.{ClickHouseCompression, ClickHouseFormat}
+import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
 
 /**
   * File builder for the ClickHouse native RowBinary file format, requires

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitBatchStorage.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitBatchStorage.scala
@@ -149,14 +149,13 @@ abstract class TwoPhaseCommitBatchStorage[-B <: RecordBatch, S: JsonSerializer]
   private object Metrics {
     private val metadataSizes = TrieMap.empty[TopicPartition, DistributionSummary]
 
-    private def partitionTags(tp: TopicPartition) =
-      Seq(MetricTag("topic", tp.topic()), MetricTag("partition", tp.partition().toString))
+    private def topicTags(tp: TopicPartition) = Seq(MetricTag("topic", tp.topic()))
 
     def metadataSize(tp: TopicPartition): DistributionSummary = metadataSizes.getOrElseUpdate(
       tp,
       createDistribution(
         "kafka.commit.staged.metadata.size.bytes",
-        Seq(MetricTag("loader-thread", Thread.currentThread().getName)) ++ partitionTags(tp)
+        Seq(MetricTag("loader-thread", Thread.currentThread().getName)) ++ topicTags(tp)
       )
     )
   }

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.12.2.25")
+case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.12.3.5")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-case class KafkaConfig(image: String = "bitnami/kafka:3.3.1")
+case class KafkaConfig(image: String = "bitnami/kafka:3.3.2")
 
 trait KafkaTestFixture extends Kafka with BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Vertica.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Vertica.scala
@@ -23,7 +23,7 @@ case class VerticaConfig(
     dbName: String = "",
     user: String = "dbadmin",
     password: String = "",
-    image: String = "vertica/vertica-ce:12.0.2-0"
+    image: String = "vertica/vertica-ce:12.0.3-0"
 )
 
 trait VerticaTestFixture extends Vertica with BeforeAndAfterAll { this: Suite with DockerTestFixture =>


### PR DESCRIPTION
Expose Kafka commit metadata metrics per topic only, as the previous topic/partition combo produced way too much metrics (~30mb in our most extreme case).

Also bump versions.