### PR TITLE
Fix recovery bug in HDFS loader

### DIFF
--- a/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
+++ b/stream-loader-hadoop/src/main/scala/com/adform/streamloader/hadoop/HadoopFileStorage.scala
@@ -71,15 +71,14 @@ class HadoopFileStorage[P](
 
     log.debug(s"Moving staged file $stagingFilePath to the destination path $targetFilePath")
     if (!hadoopFS.rename(stagingFilePath, targetFilePath)) {
-      if (!isSingleBatchStored(staging)) {
-        throw new IOException(
-          s"Failed renaming file from $stagingFilePath to $targetFilePath, because $stagingFilePath does not exist"
-        )
+      if (isSingleBatchStored(staging)) {
+        log.debug(s"Target file $targetFilePath already exists, ignoring rename failure")
       } else {
         throw new IOException(s"Failed renaming file from $stagingFilePath to $targetFilePath")
       }
+    } else {
+      log.debug(s"Successfully stored staged file $stagingFilePath to the destination path $targetFilePath")
     }
-    log.debug(s"Successfully stored staged file $stagingFilePath to the destination path $targetFilePath")
   }
 
   private def isSingleBatchStored(staging: FileStaging): Boolean = {


### PR DESCRIPTION
A single HDFS loader consuming multiple Kafka partitions to a single file will write identical `(staged_path, target_path)` staging information to the Kafka offset metadata for all partitions. If it crashes after staging it will attempt recovery for each partition and each of them will attempt to do the same move `staged_path` -> `target_path` - we only care if one of them succeeds, others will fail and can be safely ignored.

This PR fixes the current behavior that always throws an exception and fails.