### PR TITLE
Add batched record metric

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,15 +38,15 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"     % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"   % "kafka-clients"     % "3.3.2",
+      "org.apache.kafka"   % "kafka-clients"     % "3.4.0",
       "org.log4s"         %% "log4s"             % "1.10.0",
       "org.anarres.lzo"    % "lzo-commons"       % "1.0.6",
-      "org.xerial.snappy"  % "snappy-java"       % "1.1.8.4",
+      "org.xerial.snappy"  % "snappy-java"       % "1.1.9.1",
       "org.lz4"            % "lz4-java"          % "1.8.0",
-      "com.github.luben"   % "zstd-jni"          % "1.5.2-5",
+      "com.github.luben"   % "zstd-jni"          % "1.5.4-1",
       "com.univocity"      % "univocity-parsers" % "2.9.1",
       "org.json4s"        %% "json4s-native"     % "4.0.6",
-      "io.micrometer"      % "micrometer-core"   % "1.10.3",
+      "io.micrometer"      % "micrometer-core"   % "1.10.4",
       "org.scalatest"     %% "scalatest"         % scalaTestVersion      % "test",
       "org.scalatestplus" %% "scalacheck-1-17"   % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"        % scalaCheckVersion     % "test",
@@ -95,9 +95,9 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.19.23",
+      "software.amazon.awssdk" % "s3"              % "2.20.5",
       "org.scalatest"         %% "scalatest"       % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.392"       % "test",
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.408"       % "test",
       "org.gaul"               % "s3proxy"         % "2.0.0"          % "test"
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,10 +16,10 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2023.0"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2023.1"
 
 addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.7.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
@@ -24,8 +24,7 @@ class ClickHouseFileRecordBatcher[R](
 
   override def constructBatch(
       fileBuilder: ClickHouseFileBuilder[R],
-      recordRanges: Seq[StreamRange],
-      recordCount: Long
+      recordRanges: Seq[StreamRange]
   ): Option[ClickHouseFileRecordBatch] = {
     fileBuilder
       .build()

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
@@ -32,30 +32,36 @@ trait RecordBatch {
 }
 
 /**
-  * A record batch builder, the base implementation takes care of counting records and keeping track
-  * of contained record ranges. Concrete implementations should additionally implement actual batch construction.
+  * A record batch builder, the base implementation takes care of keeping track of contained record ranges.
+  * Concrete implementations should additionally implement actual batch construction.
   *
   * @tparam B Type of the batches being built.
   */
 abstract class RecordBatchBuilder[+B <: RecordBatch] {
   private val recordRangeBuilders: mutable.HashMap[TopicPartition, StreamRangeBuilder] = mutable.HashMap.empty
-  private var recordCount = 0L
 
   def currentRecordRanges: Seq[StreamRange] = recordRangeBuilders.values.map(_.build()).toSeq
-  def currentRecordCount: Long = recordCount
 
   /**
     * Adds a new record to the current batch.
-    * The default implementation only counts records added and keeps track of contained record ranges.
+    * Keeps track of record ranges in the batch and delegates the actual adding to [[addToBatch]].
+    *
+    * @param record Record to add to batch.
+    * @return Actual number of records added to the batch.
     */
-  def add(record: StreamRecord): Unit = {
+  def add(record: StreamRecord): Int = {
     val tp = new TopicPartition(record.consumerRecord.topic(), record.consumerRecord.partition())
     val position = StreamPosition(record.consumerRecord.offset(), record.watermark)
     val recordRangeBuilder =
       recordRangeBuilders.getOrElseUpdate(tp, new StreamRangeBuilder(tp.topic(), tp.partition(), position))
     recordRangeBuilder.extend(position)
-    recordCount += 1
+    addToBatch(record)
   }
+
+  /**
+    * Adds a record to the underlying batch and returns the number of records actually added.
+    */
+  protected def addToBatch(record: StreamRecord): Int
 
   /**
     * Checks whether the current batch is ready. Concrete implementations can check

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/RecordBatchingSinkerTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/RecordBatchingSinkerTest.scala
@@ -85,7 +85,9 @@ class RecordBatchingSinkerTest extends AnyFunSpec with Matchers {
         groupPartitions = Set(tp),
         () =>
           new RecordBatchBuilder[TestBatch] {
-            override def isBatchReady: Boolean = currentRecordCount >= recordsPerBatch
+            private var records: Int = 0
+            override def addToBatch(record: StreamRecord): Int = { records += 1; 1 }
+            override def isBatchReady: Boolean = records >= recordsPerBatch
             override def build(): Option[TestBatch] = Some(batchProvider.newBatch(currentRecordRanges))
             override def discard(): Unit = {}
           },

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -17,7 +17,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:22.12.3.5")
+case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:23.1.3.5")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-case class KafkaConfig(image: String = "bitnami/kafka:3.3.2")
+case class KafkaConfig(image: String = "bitnami/kafka:3.4.0")
 
 trait KafkaTestFixture extends Kafka with BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/S3.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2023-01-06T18-11-18Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2023-02-10T18-48-39Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileBatcher.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/ExternalOffsetVerticaFileBatcher.scala
@@ -71,10 +71,10 @@ class ExternalOffsetVerticaFileBatcher[R](
 
     new RecordBatchBuilder[ExternalOffsetVerticaFileRecordBatch] {
 
-      override def add(record: StreamRecord): Unit = {
-        super.add(record)
-        recordFormatter(fileId, record)
-          .foreach(formatted => fileBuilder.write(formatted))
+      override def addToBatch(record: StreamRecord): Int = {
+        val formattedRecords = recordFormatter(fileId, record)
+        formattedRecords.foreach(formatted => fileBuilder.write(formatted))
+        formattedRecords.size
       }
 
       override def isBatchReady: Boolean = fileCommitStrategy.shouldCommit(

--- a/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileBatcher.scala
+++ b/stream-loader-vertica/src/main/scala/com/adform/streamloader/vertica/InRowOffsetVerticaFileBatcher.scala
@@ -42,8 +42,7 @@ class InRowOffsetVerticaFileRecordBatcher[R](
 
   override def constructBatch(
       fileBuilder: VerticaFileBuilder[R],
-      recordRanges: Seq[StreamRange],
-      recordCount: Long
+      recordRanges: Seq[StreamRange]
   ): Option[InRowOffsetVerticaFileRecordBatch] = {
     fileBuilder
       .build()


### PR DESCRIPTION
Addresses the issue described in https://github.com/adform/stream-loader/issues/30.

Refactor the abstract `RecordBatchBuilder` class and require implementers to define `addToBatch` that returns the number of records added to batch instead of relying on implementers overriding the `add` method. Now the `add` method only keeps track of record ranges and no longer does record counting, which previously was always assumed to be one per record - this is obviously not the case if implementations do filtering or exploding of records. The number of batched records is now exposed as a metric `records.batched`.

Also bump versions.