### PR TITLE
Use full record range in partitioned record batch

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitionedFileRecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitionedFileRecordBatch.scala
@@ -15,22 +15,16 @@ import com.adform.streamloader.sink.batch.RecordBatch
   * A record batch that is partitioned by some value, e.g. by date.
   *
   * @param partitionBatches Mapping of file record batch per partition.
+  * @param recordRanges The overall record ranges contained in the batch.
   * @tparam P Type of the partitioning information, e.g. date or a tuple of client/country, etc.
   * @tparam B Type of the file record batches.
   */
-case class PartitionedFileRecordBatch[P, +B <: FileRecordBatch](partitionBatches: Map[P, B]) extends RecordBatch {
+case class PartitionedFileRecordBatch[P, +B <: FileRecordBatch](
+    partitionBatches: Map[P, B],
+    recordRanges: Seq[StreamRange]
+) extends RecordBatch {
 
   def fileBatches: Seq[B] = partitionBatches.values.toSeq
-
-  final override def recordRanges: Seq[StreamRange] = {
-    fileBatches
-      .flatMap(_.recordRanges)
-      .groupBy(r => (r.topic, r.partition))
-      .map { case ((topic, partition), ranges) =>
-        StreamRange(topic, partition, ranges.map(_.start).min, ranges.map(_.end).max)
-      }
-      .toSeq
-  }
 
   final override def discard(): Boolean = fileBatches.forall(_.discard())
 }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitioningFileRecordBatcher.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/file/PartitioningFileRecordBatcher.scala
@@ -88,7 +88,7 @@ class PartitioningFileRecordBatcher[P, R](
         } yield (partition, batch)
 
         if (batches.nonEmpty)
-          Some(PartitionedFileRecordBatch(batches.toMap))
+          Some(PartitionedFileRecordBatch(batches.toMap, currentRecordRanges))
         else
           None
       }

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/RecordBatchBuilderTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/sink/batch/RecordBatchBuilderTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.sink.batch
+
+import com.adform.streamloader.model.Generators._
+import com.adform.streamloader.model.{StreamPosition, StreamRange, StreamRecord, Timestamp}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class RecordBatchBuilderTest extends AnyFunSpec with Matchers {
+
+  case class EmptyRecordBatch(recordRanges: Seq[StreamRange]) extends RecordBatch {
+    override def discard(): Boolean = true
+  }
+
+  object EmptyRecordBatch {
+    class Builder extends RecordBatchBuilder[EmptyRecordBatch] {
+      override protected def addToBatch(record: StreamRecord): Int = 1
+      override def isBatchReady: Boolean = true
+      override def build(): Option[EmptyRecordBatch] = Some(EmptyRecordBatch(currentRecordRanges))
+      override def discard(): Unit = {}
+    }
+  }
+
+  it("should correctly extend record ranges") {
+    val builder = new EmptyRecordBatch.Builder()
+
+    builder.add(newStreamRecord("topic", 1, 0, Timestamp(0L)))
+    builder.add(newStreamRecord("topic", 1, 10, Timestamp(10L)))
+    builder.add(newStreamRecord("topic", 1, 11, Timestamp(9L)))
+
+    builder.add(newStreamRecord("topic", 2, 1, Timestamp(1L)))
+    builder.add(newStreamRecord("topic", 2, 2, Timestamp(11L)))
+
+    val batch = builder.build().get
+
+    batch.recordRanges should contain theSameElementsAs Seq(
+      StreamRange("topic", 1, StreamPosition(0, Timestamp(0L)), StreamPosition(11, Timestamp(10L))),
+      StreamRange("topic", 2, StreamPosition(1, Timestamp(1L)), StreamPosition(2, Timestamp(11L)))
+    )
+  }
+}

--- a/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/HadoopFileStorageTest.scala
+++ b/stream-loader-hadoop/src/test/scala/com/adform/streamloader/hadoop/HadoopFileStorageTest.scala
@@ -57,7 +57,7 @@ class HadoopFileStorageTest extends AnyFunSpec with Matchers {
 
     val sourceFile = File.createTempFile("test", "txt")
     val fileBatch = SingleFileRecordBatch(sourceFile, Seq(StreamRange(tp.topic(), tp.partition(), start, end)))
-    val batch = PartitionedFileRecordBatch[Unit, SingleFileRecordBatch](Map(() -> fileBatch))
+    val batch = PartitionedFileRecordBatch[Unit, SingleFileRecordBatch](Map(() -> fileBatch), fileBatch.recordRanges)
     val destFile = new File(s"${baseDir.getAbsolutePath}/stored/filename")
 
     try {

--- a/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3FileStorageTest.scala
+++ b/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/S3FileStorageTest.scala
@@ -50,7 +50,7 @@ class S3FileStorageTest extends AnyFunSpec with Matchers with MockS3 {
 
     val sourceFile = File.createTempFile("test", "txt")
     val fileBatch = SingleFileRecordBatch(sourceFile, Seq(StreamRange(tp.topic(), tp.partition(), start, end)))
-    val batch = PartitionedFileRecordBatch[Unit, SingleFileRecordBatch](Map(() -> fileBatch))
+    val batch = PartitionedFileRecordBatch[Unit, SingleFileRecordBatch](Map(() -> fileBatch), fileBatch.recordRanges)
 
     try {
       storage.commitBatch(batch)


### PR DESCRIPTION
Addresses issue #32.

The `PartitionedFileRecordBatch` class calculates the overall record range as `min/max` of the contained partition batches, however the issue is that partitions are formed after formatting records, which can potentially skip records thus ending up with an incomplete overall range. This PR contains a test case that illustrates the issue. A consequence of this is not committing offsets to Kafka frequently enough, e.g. consider a loader that places every 100th record to a batch - it would have to reprocess and skip up to 100 records after restart even though it already consumed them before.

Such behavior is inconsistent with all other batchers that always count the full record range, including records that were skipped by the formatting stage. This PR updates the partitioned batcher to always include the full overall range that now has to be passed explicitly during construction.

Also added a test for `RecordBatchBuilderTest`.