### PR TITLE
Fix nullpointer bug

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitMetadata.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/storage/TwoPhaseCommitMetadata.scala
@@ -75,7 +75,7 @@ object TwoPhaseCommitMetadata extends Logging {
         case Success(decompressed) => TwoPhaseCommitMetadata.tryParseJson[S](decompressed)
         case Failure(ex) =>
           log.error(ex)(s"Failed decompressing base64 encoded metadata '$metadata'")
-          null
+          None
       }
     } else {
       TwoPhaseCommitMetadata.tryParseJson[S](new String(bytes, "UTF-8"))


### PR DESCRIPTION
After resetting offsets streamloader fails to recover partitions

```
java.lang.NullPointerException: Cannot invoke "scala.Option.map(scala.Function1)" because "metadata" is null
```