### PR TITLE
Stale watermark after partition revoked fix

### DIFF
--- a/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
@@ -89,7 +89,7 @@ class KafkaSource(
         partitions.forEach(tp => {
           watermarkProviders.remove(tp)
           removeMeters(watermarkMetricGauges(tp))
-          watermarkMetricGauges.remove(tp).foreach(_.close())
+          watermarkMetricGauges.remove(tp)
         })
         listener.onPartitionsRevoked(partitions)
       }

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/source/KafkaSource.scala
@@ -88,6 +88,7 @@ class KafkaSource(
       override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
         partitions.forEach(tp => {
           watermarkProviders.remove(tp)
+          removeMeters(watermarkMetricGauges(tp))
           watermarkMetricGauges.remove(tp).foreach(_.close())
         })
         listener.onPartitionsRevoked(partitions)


### PR DESCRIPTION
We noticed bug where some loaders appeared to have linearly growing watermark.delay.ms. Investigation revealed that after consumer rebalance loaders still emit watermark.delay.ms metric for parition that they not longer consume. This PR adds logic to remove watermark gauge from metric registry after partion revoked event. 

I belive .close() call on removed gauges was meant to remove metric, but this function only invokes empty default implementation form https://github.com/micrometer-metrics/micrometer/blob/1.10.x/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java#L483. This method is not overriden in Gauge.