### PR TITLE
pin kafka in integration test to working immutable version

### DIFF
--- a/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
+++ b/stream-loader-tests/src/it/scala/com/adform/streamloader/fixtures/Kafka.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-case class KafkaConfig(image: String = "bitnami/kafka:3.4.0")
+case class KafkaConfig(image: String = "bitnami/kafka:3.4.0-debian-11-r21")
 
 trait KafkaTestFixture extends Kafka with BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite with DockerTestFixture =>


### PR DESCRIPTION
pinned kafka image in integration tests to bitnami/kafka:3.4.0-debian-11-r21
bitnami/kafka:3.4.0 image is overwritten on each release. after release r22 integration test stopped working