### PR TITLE
Record batch merging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "stream-loader"
 
 ThisBuild / organization := "com.adform"
 ThisBuild / organizationName := "Adform"
-ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / scalaVersion := "2.13.15"
 ThisBuild / scalacOptions := Seq(
   "-unchecked",
   "-deprecation",
@@ -38,9 +38,9 @@ val scalaTestVersion = "3.2.19"
 val scalaCheckVersion = "1.18.1"
 val scalaCheckTestVersion = "3.2.19.0"
 
-val hadoopVersion = "3.4.0"
-val parquetVersion = "1.14.2"
-val icebergVersion = "1.6.1"
+val hadoopVersion = "3.4.1"
+val parquetVersion = "1.14.4"
+val icebergVersion = "1.7.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -51,19 +51,19 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"     % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"   % "kafka-clients"     % "3.8.0",
+      "org.apache.kafka"   % "kafka-clients"     % "3.9.0",
       "org.log4s"         %% "log4s"             % "1.10.0",
       "org.apache.commons" % "commons-compress"  % "1.27.1",
       "org.xerial.snappy"  % "snappy-java"       % "1.1.10.7",
       "org.lz4"            % "lz4-java"          % "1.8.0",
-      "com.github.luben"   % "zstd-jni"          % "1.5.6-5",
+      "com.github.luben"   % "zstd-jni"          % "1.5.6-8",
       "com.univocity"      % "univocity-parsers" % "2.9.1",
       "org.json4s"        %% "json4s-native"     % "4.0.7",
-      "io.micrometer"      % "micrometer-core"   % "1.13.4",
+      "io.micrometer"      % "micrometer-core"   % "1.14.1",
       "org.scalatest"     %% "scalatest"         % scalaTestVersion      % "test",
       "org.scalatestplus" %% "scalacheck-1-18"   % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"        % scalaCheckVersion     % "test",
-      "ch.qos.logback"     % "logback-classic"   % "1.5.8"               % "test"
+      "ch.qos.logback"     % "logback-classic"   % "1.5.12"              % "test"
     )
   )
 
@@ -74,8 +74,8 @@ lazy val `stream-loader-clickhouse` = project
   .settings(
     resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "org.apache.httpcomponents.client5" % "httpclient5"     % "5.3.1",
-      "com.clickhouse"                    % "clickhouse-jdbc" % "0.6.5",
+      "org.apache.httpcomponents.client5" % "httpclient5"     % "5.4.1",
+      "com.clickhouse"                    % "clickhouse-jdbc" % "0.7.1",
       "org.scalatest"                    %% "scalatest"       % scalaTestVersion      % "test",
       "org.scalatestplus"                %% "scalacheck-1-18" % scalaCheckTestVersion % "test",
       "org.scalacheck"                   %% "scalacheck"      % scalaCheckVersion     % "test"
@@ -116,14 +116,14 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.28.3",
+      "software.amazon.awssdk" % "s3"              % "2.29.20",
       "org.scalatest"         %% "scalatest"       % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.772"       % "test",
-      "org.gaul"               % "s3proxy"         % "2.2.0"          % "test"
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.778"       % "test",
+      "org.gaul"               % "s3proxy"         % "2.4.1"          % "test"
     )
   )
 
-val verticaVersion = "24.3.0-0"
+val verticaVersion = "24.4.0-0"
 
 lazy val `stream-loader-vertica` = project
   .in(file("stream-loader-vertica"))
@@ -138,7 +138,7 @@ lazy val `stream-loader-vertica` = project
     )
   )
 
-val duckdbVersion = "1.1.0"
+val duckdbVersion = "1.1.3"
 
 lazy val packAndSplitJars =
   taskKey[(File, File)]("Runs pack and splits out the application jars from the external dependency jars")
@@ -161,17 +161,17 @@ lazy val `stream-loader-tests` = project
   .settings(
     libraryDependencies ++= Seq(
       "com.typesafe"                     % "config"                           % "1.4.3",
-      "ch.qos.logback"                   % "logback-classic"                  % "1.5.8",
-      "com.zaxxer"                       % "HikariCP"                         % "5.1.0",
+      "ch.qos.logback"                   % "logback-classic"                  % "1.5.12",
+      "com.zaxxer"                       % "HikariCP"                         % "6.2.1",
       "org.apache.iceberg"               % "iceberg-parquet"                  % icebergVersion,
       "com.vertica.jdbc"                 % "vertica-jdbc"                     % verticaVersion,
       "org.scalacheck"                  %% "scalacheck"                       % scalaCheckVersion,
       "org.scalatest"                   %% "scalatest"                        % scalaTestVersion      % "test",
       "org.scalatestplus"               %% "scalacheck-1-18"                  % scalaCheckTestVersion % "test",
       "org.slf4j"                        % "log4j-over-slf4j"                 % "2.0.16"              % "test",
-      "org.mandas"                       % "docker-client"                    % "7.0.8"               % "test",
-      "org.jboss.resteasy"               % "resteasy-client"                  % "6.2.10.Final"        % "test",
-      "com.fasterxml.jackson.jakarta.rs" % "jackson-jakarta-rs-json-provider" % "2.17.2"              % "test",
+      "org.mandas"                       % "docker-client"                    % "8.0.3"               % "test",
+      "org.jboss.resteasy"               % "resteasy-client"                  % "6.2.11.Final"        % "test",
+      "com.fasterxml.jackson.jakarta.rs" % "jackson-jakarta-rs-json-provider" % "2.18.1"              % "test",
       "org.duckdb"                       % "duckdb_jdbc"                      % duckdbVersion         % "test"
     ),
     inConfig(IntegrationTest)(Defaults.testTasks),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.20")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
@@ -16,10 +16,10 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2024.7"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2024.8"
 
 addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.8.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")

--- a/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
+++ b/stream-loader-core/src/main/scala/com/adform/streamloader/sink/batch/RecordBatch.scala
@@ -32,6 +32,17 @@ trait RecordBatch {
 }
 
 /**
+  * Appendable sequential record batches can be chained together to form new merged batches.
+  */
+trait AppendableRecordBatch[B <: RecordBatch] extends RecordBatch {
+
+  /**
+    * Returns a new batch that is the result of appending the `next` batch to the current batch.
+    */
+  def appended(next: B): B
+}
+
+/**
   * A record batch builder, the base implementation takes care of keeping track of contained record ranges.
   * Concrete implementations should additionally implement actual batch construction.
   *

--- a/stream-loader-core/src/test/scala/com/adform/streamloader/model/StreamRangeTest.scala
+++ b/stream-loader-core/src/test/scala/com/adform/streamloader/model/StreamRangeTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Adform
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.adform.streamloader.model
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class StreamRangeTest extends AnyFunSpec with Matchers {
+
+  it("should merge ranges from the same topic partition") {
+    val prev = StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2)))
+    val next = StreamRange("topic", 0, StreamPosition(2, Timestamp(2)), StreamPosition(4, Timestamp(4)))
+    val merged = StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(4, Timestamp(4)))
+
+    StreamRange.merge(prev, next) shouldEqual merged
+  }
+
+  it("should throw when attempting to merge ranges from different topic partitions") {
+    val prev = StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2)))
+    val next = StreamRange("topic", 1, StreamPosition(2, Timestamp(2)), StreamPosition(4, Timestamp(4)))
+
+    assertThrows[AssertionError](StreamRange.merge(prev, next))
+  }
+
+  it("should merge sequence of ranges correctly when topics and partitions overlap") {
+    val prev = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2))),
+      StreamRange("topic", 1, StreamPosition(10, Timestamp(10)), StreamPosition(20, Timestamp(20)))
+    )
+    val next = Seq(
+      StreamRange("topic", 0, StreamPosition(2, Timestamp(2)), StreamPosition(4, Timestamp(4))),
+      StreamRange("topic", 1, StreamPosition(20, Timestamp(20)), StreamPosition(40, Timestamp(40)))
+    )
+
+    val merged = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(4, Timestamp(4))),
+      StreamRange("topic", 1, StreamPosition(10, Timestamp(10)), StreamPosition(40, Timestamp(40)))
+    )
+
+    StreamRange.merge(prev, next) should contain theSameElementsAs merged
+  }
+
+  it("should merge sequence of ranges correctly when topics and partitions do not overlap") {
+    val prev = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2)))
+    )
+    val next = Seq(
+      StreamRange("topic", 1, StreamPosition(20, Timestamp(20)), StreamPosition(40, Timestamp(40)))
+    )
+
+    val merged = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2))),
+      StreamRange("topic", 1, StreamPosition(20, Timestamp(20)), StreamPosition(40, Timestamp(40)))
+    )
+
+    StreamRange.merge(prev, next) should contain theSameElementsAs merged
+  }
+
+  it("should merge sequence of ranges correctly when topics and partitions are mixed") {
+    val prev = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(2, Timestamp(2))),
+      StreamRange("topic", 1, StreamPosition(10, Timestamp(10)), StreamPosition(20, Timestamp(20))),
+      StreamRange("topic", 2, StreamPosition(100, Timestamp(100)), StreamPosition(200, Timestamp(200)))
+    )
+    val next = Seq(
+      StreamRange("topic", 0, StreamPosition(2, Timestamp(2)), StreamPosition(4, Timestamp(4))),
+      StreamRange("topic", 1, StreamPosition(20, Timestamp(20)), StreamPosition(40, Timestamp(40))),
+      StreamRange("topic", 3, StreamPosition(2000, Timestamp(2000)), StreamPosition(4000, Timestamp(4000)))
+    )
+
+    val merged = Seq(
+      StreamRange("topic", 0, StreamPosition(1, Timestamp(1)), StreamPosition(4, Timestamp(4))),
+      StreamRange("topic", 1, StreamPosition(10, Timestamp(10)), StreamPosition(40, Timestamp(40))),
+      StreamRange("topic", 2, StreamPosition(100, Timestamp(100)), StreamPosition(200, Timestamp(200))),
+      StreamRange("topic", 3, StreamPosition(2000, Timestamp(2000)), StreamPosition(4000, Timestamp(4000)))
+    )
+
+    StreamRange.merge(prev, next) should contain theSameElementsAs merged
+  }
+}

--- a/stream-loader-tests/src/main/resources/application-iceberg.conf
+++ b/stream-loader-tests/src/main/resources/application-iceberg.conf
@@ -4,5 +4,6 @@ stream-loader {
   iceberg {
     warehouse-dir = ${ICEBERG_WAREHOUSE_DIR}
     table = ${ICEBERG_TABLE}
+    commit-delay = ${ICEBERG_COMMIT_DELAY_MS} ms
   }
 }

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -8,16 +8,14 @@
 
 package com.adform.streamloader.fixtures
 
-import java.time.Duration
-
-import org.mandas.docker.client.messages.ContainerConfig.Healthcheck
-import org.mandas.docker.client.messages.{ContainerConfig, HostConfig}
 import org.log4s.getLogger
+import org.mandas.docker.client.messages.{ContainerConfig, Healthcheck, HostConfig}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
+import java.time.Duration
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:24.4.3.25")
+case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:24.10.2.80")
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Kafka.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Kafka.scala
@@ -8,25 +8,23 @@
 
 package com.adform.streamloader.fixtures
 
-import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{TimeUnit, TimeoutException}
-import java.util.{Properties, UUID}
-
-import org.mandas.docker.client.messages.ContainerConfig.Healthcheck
-import org.mandas.docker.client.messages.{ContainerConfig, HostConfig}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.common.TopicPartition
 import org.log4s.getLogger
+import org.mandas.docker.client.messages.{ContainerConfig, Healthcheck, HostConfig}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{TimeUnit, TimeoutException}
+import java.util.{Properties, UUID}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-case class KafkaConfig(image: String = "bitnami/kafka:3.7.0-debian-12-r0")
+case class KafkaConfig(image: String = "bitnami/kafka:3.9.0-debian-12-r3")
 
 trait KafkaTestFixture extends Kafka with BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite with DockerTestFixture =>

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/S3.scala
@@ -8,19 +8,17 @@
 
 package com.adform.streamloader.fixtures
 
-import java.net.URI
-
-import org.mandas.docker.client.messages.ContainerConfig.Healthcheck
-import org.mandas.docker.client.messages.{ContainerConfig, HostConfig}
 import org.log4s.getLogger
+import org.mandas.docker.client.messages.{ContainerConfig, Healthcheck, HostConfig}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 
+import java.net.URI
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2024-04-18T19-09-19Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2024-11-07T00-52-20Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Vertica.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Vertica.scala
@@ -8,14 +8,12 @@
 
 package com.adform.streamloader.fixtures
 
-import java.sql.DriverManager
-import java.time.Duration
-
-import org.mandas.docker.client.messages.ContainerConfig.Healthcheck
-import org.mandas.docker.client.messages.{ContainerConfig, HostConfig}
 import org.log4s.getLogger
+import org.mandas.docker.client.messages.{ContainerConfig, Healthcheck, HostConfig}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
+import java.sql.DriverManager
+import java.time.Duration
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
@@ -23,7 +21,7 @@ case class VerticaConfig(
     dbName: String = "",
     user: String = "dbadmin",
     password: String = "",
-    image: String = "vertica/vertica-ce:24.1.0-0"
+    image: String = "opentext/vertica-ce:24.4.0-1"
 )
 
 trait VerticaTestFixture extends Vertica with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
@@ -81,6 +79,11 @@ trait Vertica { this: Docker =>
       .hostConfig(
         HostConfig
           .builder()
+          .ulimits(
+            Seq(
+              HostConfig.Ulimit.builder().name("nofile").hard(65536).soft(65536).build()
+            ).asJava
+          )
           .networkMode(dockerNetwork.id)
           .portBindings(makePortBindings(verticaPort))
           .build()

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/storage/IcebergStorageBackend.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/storage/IcebergStorageBackend.scala
@@ -28,7 +28,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.sql.DriverManager
-import java.time.{Instant, LocalDateTime, ZoneId}
+import java.time.{Duration, Instant, LocalDateTime, ZoneId}
 import java.util.UUID
 import java.util.zip.GZIPInputStream
 import scala.math.BigDecimal.RoundingMode.RoundingMode
@@ -39,7 +39,8 @@ case class IcebergStorageBackend(
     dockerNetwork: DockerNetwork,
     kafkaContainer: ContainerWithEndpoint,
     loader: Loader,
-    table: String
+    table: String,
+    commitDelay: Duration
 ) extends StorageBackend[ExampleMessage] {
 
   implicit private val scalePrecision: ScalePrecision = ExampleMessage.SCALE_PRECISION
@@ -92,7 +93,8 @@ case class IcebergStorageBackend(
         s"KAFKA_CONSUMER_GROUP=${loaderKafkaConfig.consumerGroup}",
         s"BATCH_SIZE=$batchSize",
         s"ICEBERG_WAREHOUSE_DIR=$warehouseDir",
-        s"ICEBERG_TABLE=$table"
+        s"ICEBERG_TABLE=$table",
+        s"ICEBERG_COMMIT_DELAY_MS=${commitDelay.toMillis}"
       )
       .hostConfig(
         HostConfig


### PR DESCRIPTION
**Motivation**

The current batch committing algorithm works by preparing record batches, adding them to a FIFO blocking queue and running a separate batch commit thread that takes batches sequentially one-by-once and commits them to storage. The queue size is configurable and once reached the sink is blocked until it clears up.

In high throughput situations the sink may end up forming lots of batches (either because they're too small or there's too much data) and invoking commits faster than the storage can keep up with. This becomes a bottleneck for the loader and is detrimental to the storage too, as there's lots of activity.

Some storages, e.g. Iceberg, support batch merging, i.e. a single batch contains a list of files, so merging batches simply amounts to unioning files from all the batches to a single list and unioning their record ranges. Doing this is a win-win, because there's less queuing in the loader and less commits to the Iceberg table.

**Implementation**

We define a new trait `AppendableRecordBatch` that can be mixed in to `RecordBatch` implementations, users have to then implement `appended(next: B): B` to specify the batch merging implementation. As discussed above, an `IcebergRecordBatch` simply merges file lists.

The `RecordBatchingSinker` then attempts to merge any queued up batches that implement `AppendableRecordBatch` before submitting them to storage.

To test the implementation we add an extra Iceberg loader integration test that introduces an artificial delay of 1 second to the local Iceberg catalog commit method, a commit queue of length 5 and then rapidly submit 10 records batches, which forces the sink to do merging.

**Potential future improvements**

The batch committing algorithm runs independently for each Kafka partition group, meaning that if multiple threads of the Iceberg sink are being run in a single process, each one commits batches separately and the merging only happens per thread. Technically this can be optimized further by storing all batches from all threads in a single queue and merging globally. This would even further reduce the number of commits and more importantly reduce contention, as an Iceberg table has to be committed to sequentially, otherwise it gets concurrently modified exceptions and has to retry (which is why there's locking support in the current storage implementation).

However this would require a more extensive refactoring that we leave for future work.

**Other changes**

Bump all versions.
