### PR TITLE
Update versions, migrate to ClickHouse client-v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "stream-loader"
 
-ThisBuild / scalaVersion := "2.13.15"
+ThisBuild / scalaVersion := "2.13.17"
 ThisBuild / scalacOptions := Seq(
   "-unchecked",
   "-deprecation",
@@ -25,12 +25,12 @@ ThisBuild / git.remoteRepo := {
 }
 
 val scalaTestVersion = "3.2.19"
-val scalaCheckVersion = "1.18.1"
+val scalaCheckVersion = "1.19.0"
 val scalaCheckTestVersion = "3.2.19.0"
 
-val hadoopVersion = "3.4.1"
-val parquetVersion = "1.15.2"
-val icebergVersion = "1.7.0"
+val hadoopVersion = "3.4.2"
+val parquetVersion = "1.16.0"
+val icebergVersion = "1.10.0"
 
 lazy val `stream-loader-core` = project
   .in(file("stream-loader-core"))
@@ -41,19 +41,19 @@ lazy val `stream-loader-core` = project
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, git.gitHeadCommit),
     libraryDependencies ++= Seq(
       "org.scala-lang"     % "scala-reflect"     % scalaVersion.value,
-      "org.apache.kafka"   % "kafka-clients"     % "3.9.0",
+      "org.apache.kafka"   % "kafka-clients"     % "4.1.0",
       "org.log4s"         %% "log4s"             % "1.10.0",
-      "org.apache.commons" % "commons-compress"  % "1.27.1",
-      "org.xerial.snappy"  % "snappy-java"       % "1.1.10.7",
+      "org.apache.commons" % "commons-compress"  % "1.28.0",
+      "org.xerial.snappy"  % "snappy-java"       % "1.1.10.8",
       "org.lz4"            % "lz4-java"          % "1.8.0",
-      "com.github.luben"   % "zstd-jni"          % "1.5.6-8",
+      "com.github.luben"   % "zstd-jni"          % "1.5.7-5",
       "com.univocity"      % "univocity-parsers" % "2.9.1",
       "org.json4s"        %% "json4s-native"     % "4.0.7",
-      "io.micrometer"      % "micrometer-core"   % "1.14.1",
+      "io.micrometer"      % "micrometer-core"   % "1.15.4",
       "org.scalatest"     %% "scalatest"         % scalaTestVersion      % "test",
       "org.scalatestplus" %% "scalacheck-1-18"   % scalaCheckTestVersion % "test",
       "org.scalacheck"    %% "scalacheck"        % scalaCheckVersion     % "test",
-      "ch.qos.logback"     % "logback-classic"   % "1.5.12"              % "test"
+      "ch.qos.logback"     % "logback-classic"   % "1.5.19"              % "test"
     )
   )
 
@@ -64,8 +64,8 @@ lazy val `stream-loader-clickhouse` = project
   .settings(
     resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "org.apache.httpcomponents.client5" % "httpclient5"     % "5.4.1",
-      "com.clickhouse"                    % "clickhouse-jdbc" % "0.7.1",
+      "org.apache.httpcomponents.client5" % "httpclient5"     % "5.5.1",
+      "com.clickhouse"                    % "client-v2"       % "0.9.2",
       "org.scalatest"                    %% "scalatest"       % scalaTestVersion      % "test",
       "org.scalatestplus"                %% "scalacheck-1-18" % scalaCheckTestVersion % "test",
       "org.scalacheck"                   %% "scalacheck"      % scalaCheckVersion     % "test"
@@ -106,14 +106,14 @@ lazy val `stream-loader-s3` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "s3"              % "2.29.20",
+      "software.amazon.awssdk" % "s3"              % "2.35.5",
       "org.scalatest"         %% "scalatest"       % scalaTestVersion % "test",
-      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.778"       % "test",
-      "org.gaul"               % "s3proxy"         % "2.4.1"          % "test"
+      "com.amazonaws"          % "aws-java-sdk-s3" % "1.12.792"       % "test",
+      "org.gaul"               % "s3proxy"         % "2.8.0"          % "test"
     )
   )
 
-val verticaVersion = "24.4.0-0"
+val verticaVersion = "25.3.0-0"
 
 lazy val `stream-loader-vertica` = project
   .in(file("stream-loader-vertica"))
@@ -128,7 +128,8 @@ lazy val `stream-loader-vertica` = project
     )
   )
 
-val duckdbVersion = "1.1.3"
+val duckdbVersion = "1.4.1.0"
+val jerseyVersion = "3.1.11"
 
 lazy val packAndSplitJars =
   taskKey[(File, File)]("Runs pack and splits out the application jars from the external dependency jars")
@@ -150,19 +151,21 @@ lazy val `stream-loader-tests` = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe"                     % "config"                           % "1.4.3",
-      "ch.qos.logback"                   % "logback-classic"                  % "1.5.12",
-      "com.zaxxer"                       % "HikariCP"                         % "6.2.1",
-      "org.apache.iceberg"               % "iceberg-parquet"                  % icebergVersion,
-      "com.vertica.jdbc"                 % "vertica-jdbc"                     % verticaVersion,
-      "org.scalacheck"                  %% "scalacheck"                       % scalaCheckVersion,
-      "org.scalatest"                   %% "scalatest"                        % scalaTestVersion      % "test",
-      "org.scalatestplus"               %% "scalacheck-1-18"                  % scalaCheckTestVersion % "test",
-      "org.slf4j"                        % "log4j-over-slf4j"                 % "2.0.16"              % "test",
-      "org.mandas"                       % "docker-client"                    % "8.0.3"               % "test",
-      "org.jboss.resteasy"               % "resteasy-client"                  % "6.2.11.Final"        % "test",
-      "com.fasterxml.jackson.jakarta.rs" % "jackson-jakarta-rs-json-provider" % "2.18.1"              % "test",
-      "org.duckdb"                       % "duckdb_jdbc"                      % duckdbVersion         % "test"
+      "com.typesafe"                    % "config"                    % "1.4.5",
+      "ch.qos.logback"                  % "logback-classic"           % "1.5.19",
+      "com.zaxxer"                      % "HikariCP"                  % "7.0.2",
+      "org.apache.iceberg"              % "iceberg-parquet"           % icebergVersion,
+      "com.vertica.jdbc"                % "vertica-jdbc"              % verticaVersion,
+      "org.scalacheck"                 %% "scalacheck"                % scalaCheckVersion,
+      "org.scalatest"                  %% "scalatest"                 % scalaTestVersion      % "test",
+      "org.scalatestplus"              %% "scalacheck-1-18"           % scalaCheckTestVersion % "test",
+      "org.slf4j"                       % "log4j-over-slf4j"          % "2.0.17"              % "test",
+      "org.mandas"                      % "docker-client"             % "9.0.4"               % "test",
+      "org.glassfish.jersey.core"       % "jersey-client"             % jerseyVersion         % "test",
+      "org.glassfish.jersey.inject"     % "jersey-hk2"                % jerseyVersion         % "test",
+      "org.glassfish.jersey.connectors" % "jersey-apache-connector"   % jerseyVersion         % "test",
+      "org.glassfish.jersey.media"      % "jersey-media-json-jackson" % jerseyVersion         % "test",
+      "org.duckdb"                      % "duckdb_jdbc"               % duckdbVersion         % "test"
     ),
     inConfig(IntegrationTest)(Defaults.testTasks),
     publish := {},
@@ -195,7 +198,7 @@ lazy val `stream-loader-tests` = project
       val bin = s"/opt/${name.value}/bin/"
 
       new Dockerfile {
-        from("eclipse-temurin:21.0.2_13-jre")
+        from("eclipse-temurin:21.0.8_9-jre")
 
         env("APP_CLASS_PATH" -> s"$lib/*")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,20 +4,20 @@ addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.20")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.22")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 
-addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
-libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2024.8"
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2025.8"
 
-addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.8.0")
+addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.9.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileBuilder.scala
@@ -8,8 +8,8 @@
 
 package com.adform.streamloader.clickhouse
 
-import com.adform.streamloader.sink.file.{FileBuilder, FileBuilderFactory}
-import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
+import com.adform.streamloader.sink.file.{Compression, FileBuilder, FileBuilderFactory}
+import com.clickhouse.data.ClickHouseFormat
 
 /**
   * A FileBuilder able to build files that can be loaded to ClickHouse.
@@ -26,7 +26,7 @@ trait ClickHouseFileBuilder[-R] extends FileBuilder[R] {
   /**
     * Compression to use for the files being constructed.
     */
-  def compression: ClickHouseCompression
+  def fileCompression: Compression
 }
 
 trait ClickHouseFileBuilderFactory[R] extends FileBuilderFactory[R, ClickHouseFileBuilder[R]] {

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatch.scala
@@ -8,10 +8,11 @@
 
 package com.adform.streamloader.clickhouse
 
-import java.io.File
 import com.adform.streamloader.model.StreamRange
-import com.adform.streamloader.sink.file.FileRecordBatch
-import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
+import com.adform.streamloader.sink.file.{Compression, FileRecordBatch}
+import com.clickhouse.data.ClickHouseFormat
+
+import java.io.File
 
 /**
   * A file containing a batch of records in some ClickHouse supported format that can be loaded to ClickHouse.
@@ -19,7 +20,7 @@ import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
 case class ClickHouseFileRecordBatch(
     file: File,
     format: ClickHouseFormat,
-    compression: ClickHouseCompression,
+    fileCompression: Compression,
     recordRanges: Seq[StreamRange],
     rowCount: Long
 ) extends FileRecordBatch

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/ClickHouseFileRecordBatcher.scala
@@ -32,7 +32,7 @@ class ClickHouseFileRecordBatcher[R](
         ClickHouseFileRecordBatch(
           f,
           fileBuilder.format,
-          fileBuilder.compression,
+          fileBuilder.fileCompression,
           recordRanges,
           fileBuilder.getRecordCount
         )

--- a/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
+++ b/stream-loader-clickhouse/src/main/scala/com/adform/streamloader/clickhouse/rowbinary/RowBinaryClickHouseFileBuilder.scala
@@ -10,7 +10,7 @@ package com.adform.streamloader.clickhouse.rowbinary
 
 import com.adform.streamloader.clickhouse.ClickHouseFileBuilder
 import com.adform.streamloader.sink.file.{Compression, StreamFileBuilder}
-import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
+import com.clickhouse.data.ClickHouseFormat
 
 /**
   * File builder for the ClickHouse native RowBinary file format, requires
@@ -21,7 +21,7 @@ import com.clickhouse.data.{ClickHouseCompression, ClickHouseFormat}
   * @tparam R type of the records written to files being built.
   */
 class RowBinaryClickHouseFileBuilder[-R: RowBinaryClickHouseRecordEncoder](
-    fileCompression: Compression = Compression.NONE,
+    val fileCompression: Compression = Compression.NONE,
     bufferSizeBytes: Int = 8192
 ) extends StreamFileBuilder[R](
       os => new RowBinaryClickHouseRecordStreamWriter[R](os),
@@ -31,13 +31,4 @@ class RowBinaryClickHouseFileBuilder[-R: RowBinaryClickHouseRecordEncoder](
     with ClickHouseFileBuilder[R] {
 
   override val format: ClickHouseFormat = ClickHouseFormat.RowBinary
-
-  override def compression: ClickHouseCompression = fileCompression match {
-    case Compression.NONE => ClickHouseCompression.NONE
-    case Compression.ZSTD => ClickHouseCompression.ZSTD
-    case Compression.GZIP => ClickHouseCompression.GZIP
-    case Compression.BZIP => ClickHouseCompression.BZ2
-    case Compression.LZ4 => ClickHouseCompression.LZ4
-    case _ => throw new UnsupportedOperationException(s"Compression $fileCompression is not supported by ClickHouse")
-  }
 }

--- a/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/MockS3.scala
+++ b/stream-loader-s3/src/test/scala/com/adform/streamloader/s3/MockS3.scala
@@ -15,6 +15,7 @@ import org.jclouds.blobstore.BlobStoreContext
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.core.checksums.{RequestChecksumCalculation, ResponseChecksumValidation}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.endpoints.{S3EndpointParams, S3EndpointProvider}
@@ -65,6 +66,8 @@ trait MockS3 extends BeforeAndAfterAll { this: AnyFunSpec =>
     .credentialsProvider(() => AwsBasicCredentials.create(accessKey, secretKey))
     .forcePathStyle(true)
     .endpointOverride(endpoint.url())
+    .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+    .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
     .build()
 
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/Iceberg.scala
+++ b/stream-loader-tests/src/main/scala/com/adform/streamloader/loaders/Iceberg.scala
@@ -15,15 +15,14 @@ import com.adform.streamloader.sink.file.FileCommitStrategy._
 import com.adform.streamloader.sink.file.MultiFileCommitStrategy
 import com.adform.streamloader.source.KafkaSource
 import com.adform.streamloader.util.ConfigExtensions._
-import com.adform.streamloader.util.UuidExtensions._
 import com.adform.streamloader.{Loader, StreamLoader}
 import com.typesafe.config.ConfigFactory
 import org.apache.hadoop.conf.Configuration
-import org.apache.iceberg.{FileFormat, TableMetadata, TableOperations}
 import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.{GenericRecord, Record => IcebergRecord}
 import org.apache.iceberg.hadoop.HadoopCatalog
 import org.apache.iceberg.io.{FileIO, LocationProvider}
+import org.apache.iceberg.{FileFormat, TableMetadata, TableOperations}
 
 import java.time.{Duration, ZoneOffset}
 import java.util
@@ -54,7 +53,7 @@ object TestIcebergLoader extends Loader {
       icebergRecord.setField("isEnabled", avroMessage.isEnabled)
       icebergRecord.setField("childIds", util.Arrays.asList(avroMessage.childIds: _*))
       icebergRecord.setField("parentId", avroMessage.parentId.orNull)
-      icebergRecord.setField("transactionId", avroMessage.transactionId.toBytes)
+      icebergRecord.setField("transactionId", avroMessage.transactionId)
       icebergRecord.setField("moneySpent", avroMessage.moneySpent.bigDecimal)
 
       Seq(icebergRecord)

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/VerticaIntegrationTests.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/VerticaIntegrationTests.scala
@@ -12,7 +12,6 @@ import com.adform.streamloader.behaviors.BasicLoaderBehaviors
 import com.adform.streamloader.fixtures._
 import com.adform.streamloader.storage._
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
-import org.scalatest.Ignore
 import org.scalatest.concurrent.Eventually
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,9 +21,6 @@ import org.scalatestplus.scalacheck.Checkers
 import scala.concurrent.ExecutionContext
 
 @Slow
-// Temporarily ignore Vertica tests, vertica-ce image is not available on DockerHub
-// https://github.com/vertica/vertica-containers/issues/64
-@Ignore
 class VerticaIntegrationTests
     extends AnyFunSpec
     with Matchers

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/ClickHouse.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/ClickHouse.scala
@@ -15,7 +15,12 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 import java.time.Duration
 import scala.jdk.CollectionConverters._
 
-case class ClickHouseConfig(dbName: String = "default", image: String = "clickhouse/clickhouse-server:24.10.2.80")
+case class ClickHouseConfig(
+    image: String = "clickhouse/clickhouse-server:25.9.3.48",
+    dbName: String = "default",
+    userName: String = "default",
+    password: String = "password"
+)
 
 trait ClickHouseTestFixture extends ClickHouse with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {
@@ -63,6 +68,12 @@ trait ClickHouse { this: Docker =>
           .networkMode(dockerNetwork.id)
           .portBindings(makePortBindings(jdbcPort, nativeClientPort))
           .build()
+      )
+      .env(
+        s"CLICKHOUSE_DB=${clickHouseConfig.dbName}",
+        s"CLICKHOUSE_USER=${clickHouseConfig.userName}",
+        s"CLICKHOUSE_PASSWORD=${clickHouseConfig.password}",
+        "CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1"
       )
       .healthcheck(
         Healthcheck

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Docker.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Docker.scala
@@ -10,12 +10,11 @@ package com.adform.streamloader.fixtures
 
 import java.time.Duration
 import java.util.UUID
-
 import org.mandas.docker.client.DefaultDockerClient
 import org.mandas.docker.client.DockerClient.RemoveContainerParam
-import org.mandas.docker.client.builder.resteasy.ResteasyDockerClientBuilder
 import org.mandas.docker.client.messages.{ContainerConfig, NetworkConfig, PortBinding}
 import org.log4s.getLogger
+import org.mandas.docker.client.builder.DockerClientBuilder
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import scala.jdk.CollectionConverters._
@@ -53,7 +52,7 @@ trait Docker {
 
   private var network: DockerNetwork = _
 
-  val docker: DefaultDockerClient = new ResteasyDockerClientBuilder().fromEnv().build()
+  val docker: DefaultDockerClient = DockerClientBuilder.fromEnv().build()
   val dockerSandboxId: String = UUID.randomUUID().toString
 
   val healthCheckTimeout: Duration = Duration.ofSeconds(60)

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/S3.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/S3.scala
@@ -18,7 +18,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import java.net.URI
 import scala.jdk.CollectionConverters._
 
-case class S3Config(image: String = "minio/minio:RELEASE.2024-11-07T00-52-20Z")
+case class S3Config(image: String = "minio/minio:RELEASE.2025-09-07T16-13-09Z")
 
 trait S3TestFixture extends S3 with BeforeAndAfterAll { this: Suite with DockerTestFixture =>
   override def beforeAll(): Unit = {

--- a/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Vertica.scala
+++ b/stream-loader-tests/src/test/scala/com/adform/streamloader/fixtures/Vertica.scala
@@ -18,10 +18,10 @@ import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 case class VerticaConfig(
-    dbName: String = "",
+    dbName: String = "docker",
     user: String = "dbadmin",
     password: String = "",
-    image: String = "opentext/vertica-ce:24.4.0-1"
+    image: String = "jbfavre/vertica:9.2.0-7_centos-7"
 )
 
 trait VerticaTestFixture extends Vertica with BeforeAndAfterAll { this: Suite with DockerTestFixture =>


### PR DESCRIPTION
Bumping all versions, major updates:
 - replace `clickhouse-jdbc` with `clickhouse-client-v2`, which is a pure Java client bypassing JDBC completely. A notable improvement is that we now use [deduplication tokens](https://clickhouse.com/docs/operations/settings/settings#insert_deduplication_token) to deduplicate batches on server side,
 - bring back Vertica integration tests by reverting to `jbfavre/vertica:9.2.0-7_centos-7`. The [discussion](https://github.com/vertica/vertica-containers/issues/64) about upstream docker images is still ongoing,
 - switch to `apache/kafka-native:4.1.0` based on GraalVM (fast startup!) for integration tests, as `bitnami` images are deprecated,
 - switch to `apache/hadoop:3.4.1` for HDFS integration tests, added health checks
 - removed duckdb type inference hacks, as [the underlying issue](https://github.com/duckdb/duckdb_iceberg/issues/47) has been resolved